### PR TITLE
[fix] clearer upgrade copy

### DIFF
--- a/npm-app/src/update-codebuff.ts
+++ b/npm-app/src/update-codebuff.ts
@@ -14,7 +14,7 @@ export async function updateCodebuff() {
     if (!installerInfo) {
       console.log(
         yellow(
-          "There's a new version available! Please update Codebuff to prevent errors"
+          "There's a new version available! Please update Codebuff to prevent errors (run `npm install -g codebuff` to update)."
         )
       )
       return


### PR DESCRIPTION
a customer found the current verbiage a bit too vague. not attached to the copy though, what do you think? 

we don't know what the user's installer was in this case, so i defaulted to `npm` just cuz everyone knows about it. but open to alternatives that let us avoid saying the package manager