### PR TITLE
[fix]: no longer timing out for silent terminal commands 

### DIFF
--- a/npm-app/knowledge.md
+++ b/npm-app/knowledge.md
@@ -48,6 +48,11 @@ NEXT_PUBLIC_SUPPORT_EMAIL=support@example.com
   - Better matches real terminal behavior
   - Command completion detected by shell prompt reappearance
   - Must handle command echo and prompt filtering to avoid duplicate output
+  - For command completion messages:
+    - Use shell conditionals to format output: `ec=$?; if [ $ec -eq 0 ]...`
+    - Let shell handle success/failure messaging
+    - Keeps output formatting close to where it's generated
+    - Use ANSI color codes directly in shell: `\033[32m` for green, `\033[0m` to reset
   - Sources appropriate shell RC file on startup:
     - ~/.zshrc for zsh
     - ~/.config/fish/config.fish for fish

--- a/npm-app/src/utils/terminal.ts
+++ b/npm-app/src/utils/terminal.ts
@@ -305,10 +305,6 @@ const runCommandPty = (
         )
       }
 
-      if (mode === 'assistant') {
-        console.log(green(`Command completed`))
-      }
-
       // Reset the PTY to the project root
       ptyProcess.write(`cd ${projectRoot}\r`)
 
@@ -324,7 +320,8 @@ const runCommandPty = (
   })
 
   // Write the command
-  ptyProcess.write(command + '\r')
+  const commandWithCheck = `${command}; ec=$?; if [ $ec -eq 0 ]; then printf "Command completed. "; else printf "Command failed with exit code $ec. "; fi`
+  ptyProcess.write(commandWithCheck + '\r')
 }
 
 const runCommandChildProcess = (


### PR DESCRIPTION
Open to alternative ways to solve this, but i found out that we only break out of pty if we have output so I figured we could just out "Command completed" as our terminal output as a hack to get this working.

Now, silent terminal commands finish right away:
<img width="516" alt="Screenshot 2025-02-01 at 2 02 17 AM" src="https://github.com/user-attachments/assets/8e1a4385-7b1a-4fdf-acc4-5fe0b2fd0dfd" />
