### PR TITLE
Add /clear command to reset chat

### DIFF
--- a/npm-app/src/chat-storage.ts
+++ b/npm-app/src/chat-storage.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import * as fs from 'fs'
 import { Message } from 'common/types/message'
-import { getCurrentChatDir, currentChatId } from './project-files'
+import { getCurrentChatDir, getCurrentChatId } from './project-files'
 import { transformJsonInString } from 'common/util/string'
 import { type Log } from 'common/browser-actions'
 import { match, P } from 'ts-pattern'
@@ -76,7 +76,7 @@ export function setMessages(messages: Message[]) {
     const messagesPath = path.join(chatDir, 'messages.json')
 
     const messagesData = {
-      id: currentChatId,
+      id: getCurrentChatId(),
       messages: cleanedMessages,
       updatedAt: new Date().toISOString(),
     }

--- a/npm-app/src/cli.ts
+++ b/npm-app/src/cli.ts
@@ -485,6 +485,11 @@ export class CLI {
       await this.handleExit()
       return true
     }
+    if (cleanInput === 'clear') {
+      await Client.getInstance().clearContext()
+      this.freshPrompt()
+      return true
+    }
     if (['diff', 'doff', 'dif', 'iff', 'd'].includes(cleanInput)) {
       handleDiff(Client.getInstance().lastChanges)
       this.freshPrompt()

--- a/npm-app/src/client.ts
+++ b/npm-app/src/client.ts
@@ -69,6 +69,7 @@ import {
   getProjectFileContext,
   getProjectRoot,
   getWorkingDirectory,
+  startNewChat,
 } from './project-files'
 import { handleToolCall } from './tool-handlers'
 import { GitCommand, MakeNullable } from './types'
@@ -228,6 +229,18 @@ export class Client {
   public initAgentState(projectFileContext: ProjectFileContext) {
     this.agentState = getInitialAgentState(projectFileContext)
     this.fileContext = projectFileContext
+  }
+
+  public async clearContext() {
+    if (!this.fileContext) return
+    this.initAgentState(this.fileContext)
+    this.lastToolResults = []
+    this.lastChanges = []
+    this.creditsByPromptId = {}
+    checkpointManager.clearCheckpoints(true)
+    setMessages([])
+    startNewChat()
+    await this.warmContextCache()
   }
 
   private initFingerprintId(): string | Promise<string> {

--- a/npm-app/src/menu.ts
+++ b/npm-app/src/menu.ts
@@ -80,6 +80,12 @@ export const interactiveCommandDetails: CommandInfo[] = [
     // This entry will be expanded into two slash commands: /usage and /credits
   },
   {
+    commandText: '"clear"',
+    baseCommand: 'clear',
+    description: 'Clear the conversation context',
+    isSlashCommand: true,
+  },
+  {
     commandText: 'ESC key or Ctrl-C',
     description: 'Cancel generation',
     isSlashCommand: false,

--- a/npm-app/src/project-files.ts
+++ b/npm-app/src/project-files.ts
@@ -28,7 +28,16 @@ import { getScrapedContentBlocks, parseUrlsFromContent } from './web-scraper'
 
 // Global variables for chat management
 // Initialize chat ID on first import
-export const currentChatId = new Date().toISOString().replace(/:/g, '-')
+let currentChatId = new Date().toISOString().replace(/:/g, '-')
+
+export function getCurrentChatId() {
+  return currentChatId
+}
+
+export function startNewChat() {
+  currentChatId = new Date().toISOString().replace(/:/g, '-')
+  return currentChatId
+}
 
 export function isDir(p: string): boolean {
   try {
@@ -54,7 +63,7 @@ export function getProjectDataDir(): string {
 }
 
 export function getCurrentChatDir(): string {
-  const dir = path.join(getProjectDataDir(), 'chats', currentChatId)
+  const dir = path.join(getProjectDataDir(), 'chats', getCurrentChatId())
   ensureDirectoryExists(dir)
   return dir
 }


### PR DESCRIPTION
## Summary
- add `startNewChat` and `getCurrentChatId` helpers
- persist chat id via `getCurrentChatId`
- add `clearContext` on client
- wire `/clear` command into CLI and menu

## Testing
- `bun test test/__src__/patch.test.ts`