### PR TITLE
Add cost mode slash commands

### DIFF
--- a/npm-app/src/client.ts
+++ b/npm-app/src/client.ts
@@ -232,6 +232,15 @@ export class Client {
     this.fileContext = projectFileContext
   }
 
+  public setCostMode(mode: CostMode) {
+    this.costMode = mode
+    loggerContext.costMode = mode
+  }
+
+  public getCostMode(): CostMode {
+    return this.costMode
+  }
+
   private initFingerprintId(): string | Promise<string> {
     if (!this.fingerprintId) {
       this.fingerprintId = this.user?.fingerprintId ?? calculateFingerprint()

--- a/npm-app/src/menu.ts
+++ b/npm-app/src/menu.ts
@@ -109,6 +109,24 @@ export const interactiveCommandDetails: CommandInfo[] = [
     commandText: '',
   },
   {
+    baseCommand: 'lite',
+    description: 'Use cheaper Lite mode for next prompts',
+    isSlashCommand: true,
+    commandText: '',
+  },
+  {
+    baseCommand: 'max',
+    description: 'Use more thorough Max mode',
+    isSlashCommand: true,
+    commandText: '',
+  },
+  {
+    baseCommand: 'normal',
+    description: 'Return to normal mode',
+    isSlashCommand: true,
+    commandText: '',
+  },
+  {
     commandText: '"exit" or Ctrl-C x2',
     baseCommand: 'exit',
     description: 'Quit Codebuff',


### PR DESCRIPTION
## Summary
- add cost mode commands to CLI menu
- allow changing cost mode interactively and persist prefix
- keep slash menu accessible when in a cost mode

## Testing
- `bun test` *(fails: Invalid environment variables)*
- `bun run typecheck-only`