### PR TITLE
Add experimental command

### DIFF
--- a/npm-app/src/cli.ts
+++ b/npm-app/src/cli.ts
@@ -10,7 +10,7 @@ import { AnalyticsEvent } from 'common/constants/analytics-events'
 import { Message } from 'common/types/message'
 import { ProjectFileContext } from 'common/util/file'
 import { pluralize } from 'common/util/string'
-import { green, yellow, blueBright } from 'picocolors'
+import { green, yellow, blueBright, magenta } from 'picocolors'
 
 import {
   killAllBackgroundProcesses,
@@ -512,7 +512,7 @@ export class CLI {
 
   private async processCommand(userInput: string): Promise<string | null> {
     // Handle cost mode commands with optional message: /lite, /lite message, /normal, /normal message, etc.
-    const costModeMatch = userInput.match(/^\/(lite|normal|max)(?:\s+(.*))?$/i)
+    const costModeMatch = userInput.match(/^\/(lite|normal|max|experimental)(?:\s+(.*))?$/i)
     if (costModeMatch) {
       const mode = costModeMatch[1].toLowerCase() as CostMode
       const message = costModeMatch[2]?.trim() || ''
@@ -534,6 +534,8 @@ export class CLI {
         console.log(
           blueBright('⚡ Switched to max mode (slower, more thorough)')
         )
+      } else if (mode === 'experimental') {
+        console.log(magenta('🧪 Switched to experimental mode (cutting-edge)'))
       }
 
       if (!message) {

--- a/npm-app/src/menu.ts
+++ b/npm-app/src/menu.ts
@@ -134,6 +134,12 @@ export const interactiveCommandDetails: CommandInfo[] = [
     commandText: '',
   },
   {
+    baseCommand: 'experimental',
+    description: 'Switch to experimental mode (cutting-edge)',
+    isSlashCommand: false,
+    commandText: '',
+  },
+  {
     commandText: '"exit" or Ctrl-C x2',
     baseCommand: 'exit',
     description: 'Quit Codebuff',


### PR DESCRIPTION
## Summary
- add `experimental` command
- support switching to experimental cost mode

## Testing
- `npx nx build npm-app --skip-nx-cache`
- `npm test` *(fails: Preset ts-jest not found)*