### PR TITLE
Make Gemini 2.5 pro default; sonnet is now experimental

### DIFF
--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -115,9 +115,9 @@ export const getModelForMode = (
   if (operation === 'agent') {
     return {
       lite: models.gemini2_5_flash,
-      normal: models.sonnet,
-      max: models.sonnet,
-      experimental: models.gemini2_5_pro_preview,
+      normal: models.gemini2_5_pro_preview,
+      max: models.gemini2_5_pro_preview,
+      experimental: models.sonnet,
       ask: models.gemini2_5_pro_preview,
     }[costMode]
   }


### PR DESCRIPTION
This PR switches the default model from Claude Sonnet to Gemini 2.5 Pro, making Sonnet experimental instead.