### PR TITLE
fix(evals): temp fix for import paths

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,7 @@
     },
     "npm-app": {
       "name": "codebuff",
-      "version": "1.0.317",
+      "version": "1.0.318",
       "bin": {
         "codebuff": "dist/index.js",
       },

--- a/evals/git-evals/gen-evals.ts
+++ b/evals/git-evals/gen-evals.ts
@@ -4,8 +4,8 @@ import path from 'path'
 import { chunk } from 'lodash'
 import { z } from 'zod'
 
-import { claudeModels, geminiModels } from 'common/src/constants'
-import { promptAiSdkStructured } from 'backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
+import { claudeModels, geminiModels } from '../../common/src/constants'
+import { promptAiSdkStructured } from '../../backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
 import {
   CommitInfo,
   CommitSelectionSchema,

--- a/evals/git-evals/judge-git-eval.ts
+++ b/evals/git-evals/judge-git-eval.ts
@@ -1,7 +1,7 @@
-import { promptAiSdkStructured } from 'backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
-import { geminiModels } from 'common/constants'
-import { generateCompactId } from 'common/util/string'
-import { countTokens } from 'backend/src/util/token-counter'
+import { promptAiSdkStructured } from '../../backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
+import { geminiModels } from '../../common/src/constants'
+import { generateCompactId } from '../../common/src/util/string'
+import { countTokens } from '../../backend/src/util/token-counter'
 import { EvalRunLog, JudgingAnalysisSchema } from './types'
 import { createPatch } from 'diff'
 

--- a/evals/git-evals/post-eval-analysis.ts
+++ b/evals/git-evals/post-eval-analysis.ts
@@ -1,7 +1,7 @@
-import { promptAiSdkStructured } from 'backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
-import { countTokens } from 'backend/src/util/token-counter'
-import { geminiModels } from 'common/constants'
-import { generateCompactId } from 'common/util/string'
+import { promptAiSdkStructured } from '../../backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
+import { countTokens } from '../../backend/src/util/token-counter'
+import { geminiModels } from '../../common/src/constants'
+import { generateCompactId } from '../../common/src/util/string'
 import { z } from 'zod'
 import { FullEvalLog } from './types'
 
@@ -51,7 +51,7 @@ function buildAnalysisPrompt(evalResult: FullEvalLog): string {
   const metricsSection = `
 Overall Performance Metrics:
 - Average Completion Score: ${metrics.average_completion.toFixed(2)}/10
-- Average Efficiency Score: ${metrics.average_efficiency.toFixed(2)}/10  
+- Average Efficiency Score: ${metrics.average_efficiency.toFixed(2)}/10
 - Average Code Quality Score: ${metrics.average_code_quality.toFixed(2)}/10
 - Average Overall Score: ${metrics.average_overall.toFixed(2)}/10
 - Average Duration: ${(metrics.average_duration_ms / 1000).toFixed(1)} seconds

--- a/evals/git-evals/run-git-evals.ts
+++ b/evals/git-evals/run-git-evals.ts
@@ -2,12 +2,12 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
-import { promptAiSdkStructured } from 'backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
-import { claudeModels } from 'common/src/constants'
-import { withTimeout } from 'common/util/promise'
-import { generateCompactId } from 'common/util/string'
-import { setProjectRoot, setWorkingDirectory } from 'npm-app/project-files'
-import { recreateShell } from 'npm-app/terminal/base'
+import { promptAiSdkStructured } from '../../backend/src/llm-apis/vercel-ai-sdk/ai-sdk'
+import { claudeModels } from '../../common/src/constants'
+import { withTimeout } from '../../common/src/util/promise'
+import { generateCompactId } from '../../common/src/util/string'
+import { setProjectRoot, setWorkingDirectory } from '../../npm-app/src/project-files'
+import { recreateShell } from '../../npm-app/src/terminal/base'
 import {
   createFileReadingMock,
   loopMainPrompt,

--- a/evals/package.json
+++ b/evals/package.json
@@ -10,9 +10,9 @@
     "test:e2e-cat-app": "bun run e2e-cat-app-script.ts",
     "typecheck-this-package": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
-    "gen-git-evals": "bun run git-evals/gen-evals.ts",
-    "run-git-evals": "bun run git-evals/run-git-evals.ts",
-    "run-eval-set": "bun run git-evals/run-eval-set.ts",
+    "gen-git-evals": "if command -v infisical >/dev/null 2>&1; then infisical run -- bun run git-evals/gen-evals.ts; else bun run git-evals/gen-evals.ts; fi",
+    "run-git-evals": "if command -v infisical >/dev/null 2>&1; then infisical run -- bun run git-evals/run-git-evals.ts; else bun run git-evals/run-git-evals.ts; fi",
+    "run-eval-set": "if command -v infisical >/dev/null 2>&1; then infisical run -- bun run git-evals/run-eval-set.ts; else bun run git-evals/run-eval-set.ts; fi",
     "setup-codebuff-repo": "bun run setup-codebuff-repo.ts"
   },
   "dependencies": {

--- a/evals/scaffolding.ts
+++ b/evals/scaffolding.ts
@@ -3,22 +3,22 @@ import { EventEmitter } from 'events'
 import fs from 'fs'
 import path from 'path'
 
-import * as mainPromptModule from 'backend/main-prompt'
-import { ClientToolCall } from 'backend/tools'
+import * as mainPromptModule from '../backend/src/main-prompt'
+import { ClientToolCall } from '../backend/src/tools'
 import { mock } from 'bun:test'
-import { getFileTokenScores } from 'code-map/parse'
-import { FileChanges } from 'common/actions'
-import { TEST_USER_ID } from 'common/constants'
+import { getFileTokenScores } from '../packages/code-map/parse'
+import { FileChanges } from '../common/src/actions'
+import { TEST_USER_ID } from '../common/src/constants'
 import {
   getAllFilePaths,
   getProjectFileTree,
-} from 'common/src/project-file-tree'
-import { AgentState, ToolResult } from 'common/src/types/agent-state'
-import { applyAndRevertChanges } from 'common/util/changes'
-import { ProjectFileContext } from 'common/util/file'
-import { generateCompactId } from 'common/util/string'
-import { handleToolCall } from 'npm-app/tool-handlers'
-import { getSystemInfo } from 'npm-app/utils/system-info'
+} from '../common/src/project-file-tree'
+import { AgentState, ToolResult } from '../common/src/types/agent-state'
+import { applyAndRevertChanges } from '../common/src/util/changes'
+import { ProjectFileContext } from '../common/src/util/file'
+import { generateCompactId } from '../common/src/util/string'
+import { handleToolCall } from '../npm-app/src/tool-handlers'
+import { getSystemInfo } from '../npm-app/src/utils/system-info'
 import { blue } from 'picocolors'
 import { WebSocket } from 'ws'
 
@@ -284,4 +284,15 @@ export function resetRepoToCommit(projectPath: string, commit: string) {
     console.error('Error resetting repository:', error)
     throw error
   }
+}
+
+export default {
+  createFileReadingMock,
+  getProjectFileContext,
+  runMainPrompt,
+  runToolCalls,
+  loopMainPrompt,
+  extractErrorFiles,
+  applyAndRevertChangesSequentially,
+  resetRepoToCommit,
 }

--- a/evals/test-setup.ts
+++ b/evals/test-setup.ts
@@ -2,9 +2,9 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
-import { getInitialAgentState } from 'common/types/agent-state'
-import { setProjectRoot, setWorkingDirectory } from 'npm-app/project-files'
-import { recreateShell } from 'npm-app/terminal/base'
+import { getInitialAgentState } from '../common/src/types/agent-state'
+import { setProjectRoot, setWorkingDirectory } from '../npm-app/src/project-files'
+import { recreateShell } from '../npm-app/src/terminal/base'
 
 import {
   createFileReadingMock,


### PR DESCRIPTION
Temporarily fix import paths in eval scripts to be relative instead of using tsconfig paths. This is a workaround for bun run not resolving them correctly.