### PR TITLE
Add server-side restart ping functionality

### DIFF
--- a/backend/src/websockets/server.ts
+++ b/backend/src/websockets/server.ts
@@ -172,6 +172,12 @@ export function sendRequestReconnect() {
   }
 }
 
+export function sendRequestRestart() {
+  for (const ws of SWITCHBOARD.clients.keys()) {
+    sendMessage(ws, { type: 'action', data: { type: 'request-restart' } })
+  }
+}
+
 export function waitForAllClientsDisconnected() {
   return SWITCHBOARD.waitForAllClientsDisconnected()
 }

--- a/common/src/actions.ts
+++ b/common/src/actions.ts
@@ -162,6 +162,10 @@ export const SERVER_ACTION_SCHEMA = z.discriminatedUnion('type', [
     // The server is imminently going to shutdown, and the client should reconnect
     type: z.literal('request-reconnect'),
   }),
+  z.object({
+    // The server is requesting the client to restart codebuff
+    type: z.literal('request-restart'),
+  }),
 ])
 
 type ServerActionAny = z.infer<typeof SERVER_ACTION_SCHEMA>

--- a/npm-app/src/client.ts
+++ b/npm-app/src/client.ts
@@ -909,6 +909,13 @@ export class Client {
       this.reconnectWhenNextIdle()
     })
 
+    // Used to handle server requests to restart codebuff
+    this.webSocket.subscribe('request-restart', () => {
+      console.log('\n' + yellow('🔄 Codebuff needs to be restarted. Please restart the application.'))
+      console.log(red('Exiting...'))
+      this.exit()
+    })
+
     // Handle subagent streaming messages
     this.webSocket.subscribe('subagent-response-chunk', (action) => {
       const { userInputId, agentId, agentType, chunk, prompt } = action


### PR DESCRIPTION
## Summary
Adds functionality for the server to ping clients to restart codebuff and terminate the process.

## Changes
- **Backend**: Add `sendRequestRestart()` function to broadcast restart signals to all connected clients
- **Common**: Add `request-restart` action type to the server action schema  
- **Client**: Add handler to display restart message and exit process when restart signal received

## Implementation Details
- Follows the existing `request-reconnect` pattern for consistency
- Server broadcasts `request-restart` message to all clients via WebSocket
- Client displays user-friendly restart message and cleanly exits the process
- Uses established WebSocket communication infrastructure

## Test plan
- [x] TypeScript compilation passes
- [x] Follows existing code patterns and conventions
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)