### PR TITLE
Fixes for Next/Node

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": true, // don't place JS everywhere while hacking
     "baseUrl": ".", // Bun & editors see the aliases
+    "moduleResolution": "bundler",
     "paths": {
       "@codebuff/common/*": ["./common/src/*"],
       "@codebuff/backend/*": ["./backend/src/*"],


### PR DESCRIPTION
Fixes for two issues:

1. Bundler was emitting compiled JS without file extensions which doesn't work in Node environment
2. WASM files seem to not have default exports which results in an undefined import in Node