### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting Security Issues
+
+If you believe you have found a security vulnerability in CodeBuff, we encourage you to let us know right away. We will investigate all legitimate reports and do our best to quickly fix the problem.
+
+Email us at: `support@codebuff.com`
+
+Please do not report security vulnerabilities through public GitHub issues.


### PR DESCRIPTION
Adds SECURITY.md with a simple process for reporting security vulnerabilities privately.

Should I create the remaining community files ( CODE_OF_CONDUCT.md , Issue templates) or focus on other priorities?