### PR TITLE
docs: fix database setup for local development in CONTRIBUTING.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ OPEN_ROUTER_API_KEY=dummy_openrouter_key
 HELICONE_API_KEY=dummy_helicone_key
 
 # Database & Server
-DATABASE_URL=postgresql://postgres:secretpassword_local@localhost:5432/codebuff
+DATABASE_URL=postgresql://manicode_user_local:secretpassword_local@localhost:5432/manicode_db_local
 PORT=4242
 GOOGLE_CLOUD_PROJECT_ID=dummy_project_id
 
@@ -37,7 +37,7 @@ DISCORD_APPLICATION_ID=dummy_discord_app_id
 # Frontend/Public Variables
 NEXT_PUBLIC_CB_ENVIRONMENT=development
 NEXT_PUBLIC_CODEBUFF_APP_URL=http://localhost:3000
-NEXT_PUBLIC_CODEBUFF_BACKEND_URL=http://localhost:3001
+NEXT_PUBLIC_CODEBUFF_BACKEND_URL=http://localhost:4242
 NEXT_PUBLIC_SUPPORT_EMAIL=support@codebuff.com
 NEXT_PUBLIC_POSTHOG_API_KEY=phc_dummy_posthog_key
 NEXT_PUBLIC_POSTHOG_HOST_URL=https://app.posthog.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Before you begin, you'll need to install a few tools:
    Load all environment variables at once:
    ```bash
    infisical secrets set --file .env.example
-   infisical secrets set DATABASE_URL=postgresql://postgres:secretpassword_local@localhost:5432/codebuff
+   infisical secrets set DATABASE_URL=postgresql://manicode_user_local:secretpassword_local@localhost:5432/manicode_db_local
    ```
 
 5. **Configure environment**:
@@ -185,6 +185,12 @@ Level up the web interface in `web/` with better agent management, project templ
 - **direnv problems?** Make sure it's hooked into your shell, run `direnv allow`, and restart your terminal
 - **Script errors?** Double-check you're using bun for all commands
 - **Infisical issues?** See our [Infisical Setup Guide](./INFISICAL_SETUP_GUIDE.md) for step-by-step instructions
+- **Database connection errors?** If you see `password authentication failed for user "postgres"` errors:
+  1. Ensure DATABASE_URL uses the correct credentials: `postgresql://manicode_user_local:secretpassword_local@localhost:5432/manicode_db_local`
+  2. Update both your local `.env` file and Infisical secret: `infisical secrets set DATABASE_URL=postgresql://manicode_user_local:secretpassword_local@localhost:5432/manicode_db_local`
+  3. Run the database migration: `infisical run -- bun run db:migrate`
+  4. Restart your development services
+- **Empty Agent Store in dev mode?** This is expected behavior - agents from `.agents/` directory need to be published to the database to appear in the marketplace
 
 **Questions?** Jump into our [Discord community](https://codebuff.com/discord) - we're friendly and always happy to help!
 

--- a/INFISICAL_SETUP_GUIDE.md
+++ b/INFISICAL_SETUP_GUIDE.md
@@ -29,7 +29,7 @@ infisical secrets  # Verify setup works
 infisical secrets set --file .env.example
 
 # IMPORTANT: Fix the database password separately
-infisical secrets set DATABASE_URL=postgresql://postgres:secretpassword_local@localhost:5432/codebuff
+infisical secrets set DATABASE_URL=postgresql://manicode_user_local:secretpassword_local@localhost:5432/manicode_db_local
 ```
 
 ### 5. Done! Run Codebuff


### PR DESCRIPTION
## Summary
Fixes #286 - Resolves database authentication errors preventing agents from loading in local development.

## Root Cause
The CONTRIBUTING.md had incorrect database credentials in the setup instructions:
- **Wrong:** `postgresql://postgres:secretpassword_local@localhost:5432/codebuff`
- **Correct:** `postgresql://manicode_user_local:secretpassword_local@localhost:5432/manicode_db_local`

This mismatch caused `password authentication failed for user "postgres"` errors, making the Agent Store API return HTTP 500 instead of loading agents.

## Why No Agents in Dev Mode?
The Agent Store appears empty in development because:
1. **Database connection was failing** - API couldn't query the `agent_config` table (now fixed)
2. **Agents need to be published** - Local `.agents/` files are just definitions that must be published to the database via `/api/agents/publish` to appear in the marketplace
3. **Fresh dev environment** - No agents have been seeded/published yet

## Changes
- Updated DATABASE_URL in Infisical setup command with correct credentials
- Added troubleshooting section for database connection errors  
- Added explanation for empty Agent Store in dev mode (expected behavior)

## Testing
- Agent Store API now returns `[]` instead of HTTP 500 errors
- Database connection works correctly
- Development services start successfully