### PR TITLE
fix: resolve 404 errors in documentation internal links

### DIFF
--- a/web/src/content/advanced/claude-code-comparison.mdx
+++ b/web/src/content/advanced/claude-code-comparison.mdx
@@ -22,7 +22,7 @@ Codebuff might be a better choice if you value:
 
 - Speed: Codebuff is [nearly 4 times faster](https://x.com/jahooma/status/1894224663817195599)
 - Cost: Codebuff is one third the cost of Claude Code for equivalent tasks and even less for back-and-forth conversation
-- Codebase Analysis: Codebuff pulls more context from scanning your entire codebase, rather than file-by-file. Codebuff also [blends different models](/docs/advanced#what-models-do-you-use?) based on their strengths to provide more accurate results.
+- Codebase Analysis: Codebuff pulls more context from scanning your entire codebase, rather than file-by-file. Codebuff also [blends different models](/docs/advanced#what-models-do-you-use) based on their strengths to provide more accurate results.
 - Staying in Flow: Codebuff requires fewer confirmation prompts for file edits and command execution.
 - Focused changes: Codebuff does just what you asked for, while Claude Code will often get carried away editing more and more files.
 - SDK and Programmatic Access: Codebuff provides a full TypeScript SDK for programmatic integration, allowing you to create custom workflows and embed AI coding capabilities into your own tools.

--- a/web/src/content/advanced/config.mdx
+++ b/web/src/content/advanced/config.mdx
@@ -75,4 +75,4 @@ If your startup processes aren't working as expected:
 3. Check the process output in the specified log files if you've configured them
 4. Make sure the JSON syntax in your configuration file is valid
 
-Need more help? Check out our [Troubleshooting](/docs/advanced/troubleshooting) guide or join our [Discord community](https://discord.gg/mcWTGjgTj3).
+Need more help? Check out our [Troubleshooting](/docs/advanced#troubleshooting) guide or join our [Discord community](https://discord.gg/mcWTGjgTj3).

--- a/web/src/content/agents/troubleshooting-agent-customization.mdx
+++ b/web/src/content/agents/troubleshooting-agent-customization.mdx
@@ -32,7 +32,7 @@ Error: Agent 'my-custom-agent' not found
 Validation error: spawnableAgents contains invalid agent 'researcher-typo'
 ```
 
-**Fix:** Check spelling against [built-in agents list](/docs/agents/agent-reference#available-built-in-agents), use exact IDs
+**Fix:** Check spelling against [built-in agents list](/docs/agents#h2-built-in-agents), use exact IDs
 
 ### "Path not found" Error
 
@@ -294,7 +294,7 @@ If you're still experiencing issues:
 1. **Check the logs**: Look for specific error messages when starting Codebuff
 2. **Simplify**: Remove customizations until it works, then add back gradually
 3. **Community**: Join our [Discord](https://codebuff.com/discord) for real-time help
-4. **Documentation**: Review the [Agent Reference](/docs/agents/agent-reference) for complete field descriptions
+4. **Documentation**: Review the [Agent Reference](/docs/agents#agent-reference) for complete field descriptions
 
 ## Quick Reference
 

--- a/web/src/content/help/faq.mdx
+++ b/web/src/content/help/faq.mdx
@@ -88,4 +88,4 @@ Anthropic recently released [Claude Code](https://docs.anthropic.com/en/docs/age
 
 We're happy to answer! Contact us at [support@codebuff.com](mailto:support@codebuff.com) or [join our Discord](https://discord.gg/mcWTGjgTj3)!
 
-Having technical issues? Check out our [Troubleshooting](/docs/advanced/troubleshooting) guide for solutions to common problems.
+Having technical issues? Check out our [Troubleshooting](/docs/advanced#troubleshooting) guide for solutions to common problems.

--- a/web/src/content/help/getting-started.mdx
+++ b/web/src/content/help/getting-started.mdx
@@ -51,4 +51,4 @@ If you run into issues during installation:
    - Try reinstalling Node using [nvm or fnm](https://nodejs.org/en/download)
    - Run the Codebuff install command again
 
-If you're still experiencing issues, check out our [Troubleshooting](/docs/advanced/troubleshooting) guide or join our [Discord community](https://codebuff.com/discord)!
+If you're still experiencing issues, check out our [Troubleshooting](/docs/advanced#troubleshooting) guide or join our [Discord community](https://codebuff.com/discord)!


### PR DESCRIPTION
Fixed 6 broken internal links across 5 documentation files that were causing 404 errors.

## Failing Links Fixed
1. **"Blend different models"** link - Had invalid `?` in anchor
2. **Built-in agents list** link - Wrong routing pattern
3. **Agent reference** links (2 instances) - Wrong routing pattern
4. **Troubleshooting** links (3 instances) - Wrong routing pattern

## Changes Made
- **claude-code-comparison.mdx**: Fixed anchor `#what-models-do-you-use?` → `#what-models-do-you-use`
- **troubleshooting-agent-customization.mdx**: Fixed 2 agent reference links to section-based routing
- **config.mdx**: Fixed troubleshooting link routing
- **faq.mdx**: Fixed troubleshooting link routing
- **getting-started.mdx**: Fixed troubleshooting link routing

## Links Updated
- `/docs/advanced#what-models-do-you-use?` → `/docs/advanced#what-models-do-you-use`
- `/docs/agents/agent-reference` → `/docs/agents#agent-reference`
- `/docs/advanced/troubleshooting` → `/docs/advanced#troubleshooting`