### PR TITLE
[render preview] fix(web): change hero section from fixed height to min-height to prev…

### DIFF
--- a/web/src/components/ui/section.tsx
+++ b/web/src/components/ui/section.tsx
@@ -58,7 +58,7 @@ export function Section({
       className={cn('relative overflow-hidden', className)}
       initial={false}
       animate={{
-        height: fullViewport && !isMobile ? '95svh' : 'auto',
+        minHeight: fullViewport && !isMobile ? '95svh' : 'auto',
       }}
       transition={{
         duration: 1,


### PR DESCRIPTION
…ent IDE demo cutoff

Change Section component to use minHeight instead of height when fullViewport is true. This ensures the hero section maintains minimum viewport height but can expand to accommodate IDE demo content, preventing cutoff on smaller screens.

🤖 Generated with Codebuff