### PR TITLE
Minor fix in creating you first agent docs

### DIFF
--- a/web/src/content/walkthroughs/creating-your-first-agent.mdx
+++ b/web/src/content/walkthroughs/creating-your-first-agent.mdx
@@ -198,7 +198,7 @@ Publishing:
 Now anyone can use your agent:
 
 ```bash
-codebuff --agent @your-publisher-id/simple-code-reviewer@0.0.1
+codebuff --agent your-publisher-id/simple-code-reviewer@0.0.1
 ```
 
 ## Advanced Example: Deep Code Reviewer


### PR DESCRIPTION
Probably the dumbest first Codebuff PR.

Additional Codebuff checks:
```
[Update Subgoal]
Status: COMPLETE
Log: Completed extensive search across codebase. Found the original issue was already fixed in creating-your-first-agent.mdx. Searched through multiple files and patterns but did not find any other instances of the @ prefix error. The codebase appears to correctly use the format 'publisher/agent@version' without an @ prefix in command examples.

99 credits used for this request.
codebuff-alex > /
```