### PR TITLE
docs: Add configuration and environment variables section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,33 @@ Then just tell Codebuff what you want and it handles the rest:
 
 Codebuff will find the right files, makes changes across your codebase, and runs tests to make sure nothing breaks.
 
+## Configuration
+
+For most users, **no configuration is needed**. The CLI authenticates via your browser automatically when you run `codebuff`.
+
+### SDK Usage: API Keys
+
+If you're using the [Codebuff SDK](https://www.npmjs.com/package/@codebuff/sdk) (not the CLI), you'll need an API key:
+
+1. Create a Codebuff account at [codebuff.com](https://codebuff.com)
+2. Get your API key at [codebuff.com/api-keys](https://codebuff.com/api-keys)
+3. Use it in your code:
+
+```typescript
+import { CodebuffClient } from '@codebuff/sdk'
+
+const client = new CodebuffClient({
+  apiKey: process.env.CODEBUFF_API_KEY, // Store securely in environment variables
+  cwd: '/path/to/your/project',
+})
+```
+
+**Best practice**: Store your API key in a `.env` file and load it via `process.env.CODEBUFF_API_KEY`. Never commit API keys to version control.
+
+### Local Development
+
+Contributing to Codebuff? See [.env.example](./.env.example) for all available environment variables and [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed local development setup.
+
 ## Create custom agents
 
 To get started building your own agents, run:


### PR DESCRIPTION
Adds Configuration section to README explaining environment variables and API key setup for SDK users.

## What Was Added

New "Configuration" section with:
- Clarification that CLI users need no configuration (browser auth)
- SDK API key setup walkthrough with code example
- Reference to `.env.example` for all available variables
- Link to CONTRIBUTING.md for local development setup

## Why This Change

README had zero mentions of "environment", "env", "API key", or "configuration" despite having 40 environment variables in `.env.example`. SDK example shows `apiKey: 'your-api-key'` but doesn't explain where to get it.

This helps SDK users understand:
- Where to get API keys (codebuff.com/api-keys)
- How to use them securely (environment variables)
- That CLI users don't need manual configuration

## Validation

- Links to `.env.example` and CONTRIBUTING.md verified
- TypeScript code example syntax validated
- Maintains existing README style and tone