### PR TITLE
Bug: Expose types in CodebuffClientOptions

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -8,12 +8,11 @@ export type { AgentDefinition } from '../../common/src/templates/initial-agents-
 // Re-export code analysis functionality
 export * from '../../packages/code-map/src/index'
 
-export type { PublishedToolName } from '../../common/src/tools/constants'
 export type { ClientToolCall, ClientToolName, CodebuffToolOutput } from '../../common/src/tools/list'
 export * from './client'
 export * from './custom-tool'
 export * from './native/ripgrep'
 export * from './run-state'
-export { ToolHelpers } from './tools'
+export { ToolHelpers, ToolName } from './tools'
 export * from './websocket-client'
 


### PR DESCRIPTION
CodebuffClientOptions is exposed publicly but these types in the signature are not. This is helpful for strongly typing tool overrides, among other things:

```
export function changeFile(
  parameters: unknown,
  cwd: string,
): CodebuffToolOutput<'str_replace'> { ... }
```