### PR TITLE
fix: add missing env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,4 @@ NEXT_PUBLIC_POSTHOG_API_KEY=phc_dummy_posthog_key
 NEXT_PUBLIC_POSTHOG_HOST_URL=https://us.i.posthog.com
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_dummy_publishable
 NEXT_PUBLIC_STRIPE_CUSTOMER_PORTAL=https://billing.stripe.com/p/login/test_dummy
+NEXT_PUBLIC_WEB_PORT=3000


### PR DESCRIPTION
## Summary

This PR adds the missing env variable `NEXT_PUBLIC_WEB_PORT` to the file `.env.example`.

## Changes

- add new env variable at the end of `.env.example` file.

**Fixes** #426 