### PR TITLE
Fix docs: align markdown table in knowledge-files.mdx

### DIFF
--- a/web/src/content/tips/knowledge-files.mdx
+++ b/web/src/content/tips/knowledge-files.mdx
@@ -107,12 +107,12 @@ Then add your global preferences:
 
 ### When to Use Home Directory vs Project Knowledge Files
 
-| Home Directory (`~/.knowledge.md`) | Project (`knowledge.md`) |
-|-----------------------------------|------------------------------------|
-| Personal coding preferences | Project-specific conventions |
-| Preferred frameworks/tools | Architecture decisions |
-| Communication style | Build and deploy commands |
-| Global defaults | Team coding standards |
+| Home Directory (`~/.knowledge.md`) | Project (`knowledge.md`)     |
+|-----------------------------------|-----------------------------|
+| Personal coding preferences        | Project-specific conventions |
+| Preferred frameworks/tools         | Architecture decisions       |
+| Communication style                | Build and deploy commands    |
+| Global defaults                    | Team coding standards        |
 
 Both files are loaded—project knowledge files add to (and can override) your home directory preferences.
 


### PR DESCRIPTION
Fixes #447. Aligns the Home Directory vs Project Knowledge Files table in knowledge-files.mdx for proper markdown rendering.