### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/cli-release-prod.yml
+++ b/.github/workflows/cli-release-prod.yml
@@ -103,7 +103,7 @@ jobs:
           path: cli/release/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare-and-commit-prod.outputs.new_version }}
           name: Release v${{ needs.prepare-and-commit-prod.outputs.new_version }}

--- a/.github/workflows/cli-release-staging.yml
+++ b/.github/workflows/cli-release-staging.yml
@@ -176,7 +176,7 @@ jobs:
           path: cli/release-staging/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare-and-commit-staging.outputs.new_version }}
           name: Codecane v${{ needs.prepare-and-commit-staging.outputs.new_version }} (Staging)

--- a/.github/workflows/npm-app-release-legacy.yml
+++ b/.github/workflows/npm-app-release-legacy.yml
@@ -100,7 +100,7 @@ jobs:
           path: npm-app/release/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare-and-commit-legacy.outputs.new_version }}
           name: Release v${{ needs.prepare-and-commit-legacy.outputs.new_version }}

--- a/.github/workflows/npm-app-release-prod.yml
+++ b/.github/workflows/npm-app-release-prod.yml
@@ -100,7 +100,7 @@ jobs:
           path: npm-app/release/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare-and-commit-prod.outputs.new_version }}
           name: Release v${{ needs.prepare-and-commit-prod.outputs.new_version }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `softprops/action-gh-release` | [`v1`](https://github.com/softprops/action-gh-release/releases/tag/v1) | [`v2`](https://github.com/softprops/action-gh-release/releases/tag/v2) | [Release](https://github.com/softprops/action-gh-release/releases/tag/v2) | cli-release-prod.yml, cli-release-staging.yml, npm-app-release-legacy.yml, npm-app-release-prod.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **softprops/action-gh-release** (v1 → v2): Major version upgrade — review the [release notes](https://github.com/softprops/action-gh-release/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
