### PR TITLE
fix: preserve MCP tool params when MCP schemas are rendered as allOf

### DIFF
--- a/packages/agent-runtime/src/__tests__/prompts-schema-handling.test.ts
+++ b/packages/agent-runtime/src/__tests__/prompts-schema-handling.test.ts
@@ -1,5 +1,6 @@
 import { TEST_AGENT_RUNTIME_IMPL } from '@codebuff/common/testing/impl/agent-runtime'
 import { describe, test, expect, mock } from 'bun:test'
+import { convertJsonSchemaToZod } from 'zod-from-json-schema'
 import { z } from 'zod/v4'
 
 import { buildAgentToolInputSchema, buildAgentToolSet } from '../templates/prompts'
@@ -170,6 +171,30 @@ describe('Schema handling error recovery', () => {
       // The schema properties should be in the JSON output
       expect(description).toContain('path')
       expect(description).toContain('content')
+    })
+
+    test('buildToolDescription preserves MCP params when schema is represented as allOf', () => {
+      const mcpSchema = convertJsonSchemaToZod({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        required: ['name'],
+        additionalProperties: false,
+      })
+
+      const description = buildToolDescription({
+        toolName: 'greet__greet',
+        schema: mcpSchema,
+        description: 'Call greet',
+        endsAgentStep: true,
+      })
+
+      expect(description).toContain('greet__greet')
+      expect(description).toContain('Params: {')
+      expect(description).toContain('allOf')
+      expect(description).toContain('name')
+      expect(description).not.toContain('Params: None')
     })
 
     test('getToolSet handles custom tools with problematic schemas', async () => {

--- a/packages/agent-runtime/src/tools/prompts.ts
+++ b/packages/agent-runtime/src/tools/prompts.ts
@@ -53,6 +53,27 @@ function toJsonSchemaSafe(schema: z.ZodType): Record<string, unknown> {
   }
 }
 
+function hasMeaningfulJsonSchema(jsonSchema: Record<string, unknown>): boolean {
+  const properties = jsonSchema.properties
+  if (properties && typeof properties === 'object' && Object.keys(properties).length > 0) {
+    return true
+  }
+
+  for (const key of ['allOf', 'anyOf', 'oneOf']) {
+    const value = jsonSchema[key]
+    if (Array.isArray(value) && value.length > 0) {
+      return true
+    }
+  }
+
+  const required = jsonSchema.required
+  if (Array.isArray(required) && required.length > 0) {
+    return true
+  }
+
+  return false
+}
+
 function paramsSection(params: { schema: z.ZodType; endsAgentStep: boolean }) {
   const { schema, endsAgentStep } = params
   const safeSchema = ensureJsonSchemaCompatible(schema)
@@ -68,7 +89,7 @@ function paramsSection(params: { schema: z.ZodType; endsAgentStep: boolean }) {
   const jsonSchema = toJsonSchemaSafe(schemaWithEndsAgentStepParam)
   delete jsonSchema.description
   delete jsonSchema['$schema']
-  const paramsDescription = Object.keys(jsonSchema.properties ?? {}).length
+  const paramsDescription = hasMeaningfulJsonSchema(jsonSchema)
     ? JSON.stringify(jsonSchema, null, 2)
     : 'None'
 


### PR DESCRIPTION
This fixes MCP tool parameter rendering when the schema is valid but represented as `allOf` after Codebuff combines it with the end-step flag.

What was happening:
- MCP returned a valid input schema
- Codebuff converted the schema and combined it with the end-step flag
- The resulting JSON Schema could be represented as `allOf`
- `paramsSection()` only checked top-level `properties`, so it incorrectly rendered the tool as having no params

What changed:
- Treat schemas with `allOf`, `anyOf`, `oneOf`, or non-empty `required` as meaningful
- Keep rendering the full JSON Schema instead of falling back to `Params: None`

How I tested it:
- Reproduced locally with a FastMCP server matching issue #450
- Before the fix, the MCP tool description rendered `Params: None`
- After the fix, the rendered schema includes the expected `name` parameter
- Added a regression test covering the `allOf` case

Fixes #450