### PR TITLE
fix(write-file): use error.message instead of error.msg in catch block

### DIFF
--- a/packages/agent-runtime/src/tools/handlers/tool/write-file.ts
+++ b/packages/agent-runtime/src/tools/handlers/tool/write-file.ts
@@ -139,7 +139,7 @@ export const handleWriteFile = (async (
       return {
         tool: 'write_file' as const,
         path,
-        error: `Error: Failed to process the write_file block. ${typeof error === 'string' ? error : error.msg}`,
+        error: `Error: Failed to process the write_file block. ${typeof error === 'string' ? error : error.message}`,
       }
     })
     .then(async (fileProcessingResult) => ({


### PR DESCRIPTION
## Summary

Fixes a typo in the write-file tool handler where `error.msg` was used instead of `error.message`.

## Problem

The error catch block in `packages/agent-runtime/src/tools/handlers/tool/write-file.ts` accesses `error.msg` instead of `error.message`, causing all non-string error details to be lost.

Standard JavaScript `Error` objects have a `.message` property, not `.msg`. When `processFileBlock()` throws a non-string error (which is the common case), `error.msg` evaluates to `undefined`, and the error message becomes:

```
Error: Failed to process the write_file block. undefined
```

This is the only occurrence of `.msg` in the codebase — all other error handling correctly uses `.message`.

## Impact

When a file write operation fails with a non-string error, the actual error details are lost. Users and logs see "undefined" instead of the real error message, making debugging difficult.

## Fix

```diff
- error: `Error: Failed to process the write_file block. ${typeof error === 'string' ? error : error.msg}`,
+ error: `Error: Failed to process the write_file block. ${typeof error === 'string' ? error : error.message}`,
```

Fixes #464