### PR TITLE
fix(cli): check publish command at argv[2] position only

### DIFF
--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -189,7 +189,7 @@ async function main(): Promise<void> {
   } = parseArgs()
 
   const isLoginCommand = process.argv[2] === 'login'
-  const isPublishCommand = process.argv.includes('publish')
+  const isPublishCommand = process.argv[2] === 'publish'
   const hasAgentOverride = Boolean(agent?.trim())
 
   await initializeApp({ cwd })


### PR DESCRIPTION
## Summary

Fixes publish command detection to only match when 'publish' is the actual subcommand, not anywhere in the arguments.

## Problem

The CLI's publish command detection uses `process.argv.includes('publish')` which matches "publish" anywhere in the arguments, not just as a subcommand. A user prompt like "publish my changes" triggers the publish flow and exits the session.

```typescript
const isLoginCommand = process.argv[2] === 'login'       // ← positional (correct)
const isPublishCommand = process.argv.includes('publish') // ← non-positional (bug)
```

`isLoginCommand` correctly checks only `argv[2]` (the subcommand position), but `isPublishCommand` uses `includes()` which matches any argument.

## Reproduction

```bash
codebuff "publish my changes"
# Expected: starts a chat session with the prompt "publish my changes"
# Actual: triggers handlePublish() and exits
```

## Fix

```diff
  const isLoginCommand = process.argv[2] === 'login'
- const isPublishCommand = process.argv.includes('publish')
+ const isPublishCommand = process.argv[2] === 'publish'
```

Consistent with how `isLoginCommand` is detected.

Fixes #465