### PR TITLE
fix: correct code-map line counting

### DIFF
--- a/packages/code-map/__tests__/parse.test.ts
+++ b/packages/code-map/__tests__/parse.test.ts
@@ -132,7 +132,7 @@ describe('parse module', () => {
         () => multilineCode,
       )
 
-      expect(result.numLines).toBe(2) // Due to operator precedence: .match(/\n/g)?.length ?? 0 + 1 becomes (2 ?? 1) = 2
+      expect(result.numLines).toBe(3)
     })
 
     it('should deduplicate identifiers and calls', () => {

--- a/packages/code-map/src/parse.ts
+++ b/packages/code-map/src/parse.ts
@@ -169,7 +169,7 @@ export function parseTokens(
         calls: [] as string[],
       }
     }
-    const numLines = sourceCode.match(/\n/g)?.length ?? 0 + 1
+    const numLines = (sourceCode.match(/\n/g)?.length ?? 0) + 1
     if (!parser || !query) {
       throw new Error('Parser or query not found')
     }


### PR DESCRIPTION
## Summary
- fix parseTokens() so multiline files count newlines correctly by applying the nullish fallback before adding 1
- update the code-map regression test to expect the correct line count for a 3-line input

## Validation
- reproduced the root cause locally with Node: the old expression returns 2 for a 3-line string, while the fixed expression returns 3
- full bun test packages/code-map/__tests__/parse.test.ts could not be run in this environment because bun is not installed locally