### PR TITLE
docs: align model references with actual agents (Opus 4.7)

### DIFF
--- a/web/src/app/docs/[category]/[slug]/page.tsx
+++ b/web/src/app/docs/[category]/[slug]/page.tsx
@@ -38,7 +38,7 @@ const FAQ_ITEMS = [
   {
     question: 'Can I use my Claude Pro or Max subscription with Codebuff?',
     answer:
-      "Yes! If you have a Claude Pro or Max subscription, you can connect it to Codebuff and use your subscription for Claude model requests. This lets you save credits while still benefiting from Codebuff's intelligent orchestration. Run /connect:claude in the CLI to link your subscription. Note: Using your Claude Pro/Max subscription in Codebuff is not officially supported by Anthropic.",
+      'Connecting your Claude Pro or Max subscription to Codebuff is deprecated and will be removed on March 1st. At least one user had their Anthropic account disabled after heavy usage via Codebuff. We recommend switching to a Codebuff Strong subscription instead — it includes generous usage limits across all models without needing to connect an external subscription.',
   },
   {
     question: 'Is Codebuff open source?',

--- a/web/src/app/docs/[category]/[slug]/page.tsx
+++ b/web/src/app/docs/[category]/[slug]/page.tsx
@@ -33,7 +33,7 @@ const FAQ_ITEMS = [
   {
     question: 'What model does Codebuff use?',
     answer:
-      'Multiple. The orchestrator uses Claude Opus 4.6 in Default and Max modes, or GLM 5.1 in Free mode. Subagents are matched to their tasks: Claude Opus 4.6 for code editing, GPT-5.1 for deep reasoning, Grok 4.1 Fast for terminal commands and research, and Relace AI for fast file rewrites.',
+      'Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or GLM 5.1 in Lite mode. Subagents are matched to their tasks: Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research.',
   },
   {
     question: 'Can I use my Claude Pro or Max subscription with Codebuff?',

--- a/web/src/content/advanced/claude-code-comparison.mdx
+++ b/web/src/content/advanced/claude-code-comparison.mdx
@@ -14,7 +14,7 @@ Both tools:
 - Run in your terminal
 - Understand your entire codebase context
 - Can edit files and execute terminal commands
-- Use Claude models (Codebuff uses Claude Opus 4.6 as its orchestrator)
+- Use Claude models (Codebuff uses Claude Opus 4.7 as its orchestrator)
 
 ## When to Choose Codebuff
 

--- a/web/src/content/advanced/how-does-it-work.mdx
+++ b/web/src/content/advanced/how-does-it-work.mdx
@@ -22,7 +22,7 @@ The main agent ("Buffy") runs on Claude Opus 4.7. It reads your prompt, gathers 
 
 - [**File Picker**](/publishers/codebuff/agents/file-picker) (Gemini 2.0 Flash) - finds relevant files
 - [**Code Searcher**](/publishers/codebuff/agents/code-searcher) - grep-style pattern matching
-- [**Researcher**](/publishers/codebuff/agents/researcher) (Grok 4 Fast) - web and docs lookup
+- [**Researcher**](/publishers/codebuff/agents/researcher) (Gemini 3.1 Flash Lite) - web and docs lookup
 - [**Thinker**](/publishers/codebuff/agents/thinker) (Claude Opus 4.7, GPT-5.4) - works through hard problems
 - [**Editor**](/publishers/codebuff/agents/editor) (Claude Opus 4.7, GPT-5.1, GLM 5.1) - writes and modifies code
 - [**Reviewer**](/publishers/codebuff/agents/reviewer) (Claude Opus 4.7, GLM 5.1 in Lite mode) - catches bugs and style issues

--- a/web/src/content/advanced/how-does-it-work.mdx
+++ b/web/src/content/advanced/how-does-it-work.mdx
@@ -11,7 +11,7 @@ Codebuff runs multiple agents, each tuned for a specific task.
 
 ## The Orchestrator
 
-The main agent ("Buffy") runs on Claude Opus 4.6. It reads your prompt, gathers context, and spawns subagents. The orchestrator is available in several variants:
+The main agent ("Buffy") runs on Claude Opus 4.7. It reads your prompt, gathers context, and spawns subagents. The orchestrator is available in several variants:
 
 - [`base2`](/publishers/codebuff/agents/base2) - Default mode orchestrator
 - [`base2-lite`](/publishers/codebuff/agents/base2-lite) - Lite mode (faster, cheaper)
@@ -23,9 +23,9 @@ The main agent ("Buffy") runs on Claude Opus 4.6. It reads your prompt, gathers 
 - [**File Picker**](/publishers/codebuff/agents/file-picker) (Gemini 2.0 Flash) - finds relevant files
 - [**Code Searcher**](/publishers/codebuff/agents/code-searcher) - grep-style pattern matching
 - [**Researcher**](/publishers/codebuff/agents/researcher) (Grok 4 Fast) - web and docs lookup
-- [**Thinker**](/publishers/codebuff/agents/thinker) (GPT-5.1, Gemini 2.5 Pro) - works through hard problems
-- [**Editor**](/publishers/codebuff/agents/editor) (GPT-5.1, Claude Opus 4.6) - writes and modifies code
-- [**Reviewer**](/publishers/codebuff/agents/reviewer) (Claude Opus 4.6, GLM 5.1 in Lite mode) - catches bugs and style issues
+- [**Thinker**](/publishers/codebuff/agents/thinker) (Claude Opus 4.7, GPT-5.4) - works through hard problems
+- [**Editor**](/publishers/codebuff/agents/editor) (Claude Opus 4.7, GPT-5.1, GLM 5.1) - writes and modifies code
+- [**Reviewer**](/publishers/codebuff/agents/reviewer) (Claude Opus 4.7, GLM 5.1 in Lite mode) - catches bugs and style issues
 - [**Basher**](/publishers/codebuff/agents/basher) (Gemini 3.1 Flash Lite) - runs terminal commands
 
 ## Best-of-N Selection (Max Mode)

--- a/web/src/content/advanced/what-models.mdx
+++ b/web/src/content/advanced/what-models.mdx
@@ -19,7 +19,7 @@ The main agent ("Buffy") coordinates everything:
   | Default | Opus 4.7 |
   | Plan | Opus 4.7 |
   | Max | Opus 4.7 |
-  | Free | GLM 5.1 |
+  | Lite | GLM 5.1 |
 </MarkdownTable>
 
 ## Subagents
@@ -37,4 +37,4 @@ The orchestrator spawns these for specific jobs:
   | Web/docs research | Gemini 3.1 Flash Lite |
 </MarkdownTable>
 
-Max mode runs multiple implementations in parallel and picks the best one. Default mode runs a single implementation pass. Free mode uses GLM 5.1 and includes code review support.
+Max mode runs multiple implementations in parallel and picks the best one. Default mode runs a single implementation pass. Lite mode uses GLM 5.1 and includes code review support.

--- a/web/src/content/advanced/what-models.mdx
+++ b/web/src/content/advanced/what-models.mdx
@@ -16,9 +16,9 @@ The main agent ("Buffy") coordinates everything:
 <MarkdownTable>
   | Mode | Model |
   |------|-------|
-  | Default | Opus 4.6 |
-  | Plan | Opus 4.6 |
-  | Max | Opus 4.6 |
+  | Default | Opus 4.7 |
+  | Plan | Opus 4.7 |
+  | Max | Opus 4.7 |
   | Free | GLM 5.1 |
 </MarkdownTable>
 
@@ -29,9 +29,9 @@ The orchestrator spawns these for specific jobs:
 <MarkdownTable>
   | Task | Models |
   |------|--------|
-  | Code editing | Claude Opus 4.6, GLM 5.1 |
-  | Thinking/reasoning | Claude Opus 4.6, GPT-5.4 |
-  | Code review | Claude Opus 4.6, GPT-5.4 |
+  | Code editing | Claude Opus 4.7, GLM 5.1 |
+  | Thinking/reasoning | Claude Opus 4.7, GPT-5.4 |
+  | Code review | Claude Opus 4.7, GPT-5.4 |
   | File discovery | Gemini 3.1 Flash Lite, Gemini 2.5 Flash Lite |
   | Terminal commands | Gemini 3.1 Flash Lite |
   | Web/docs research | Gemini 3.1 Flash Lite |

--- a/web/src/content/help/faq.mdx
+++ b/web/src/content/help/faq.mdx
@@ -13,7 +13,7 @@ Software development: Writing features, tests, and scripts across common languag
 
 ## What model does Codebuff use?
 
-Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or GLM 5.1 in Free mode. Subagents are matched to their tasks: Claude Opus 4.7 (with GLM 5.1 as a lighter option) for code editing, Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research. Free mode includes code review support. See [What models do you use?](/docs/advanced/what-models) for the full breakdown.
+Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or GLM 5.1 in Lite mode. Subagents are matched to their tasks: Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research. See [What models do you use?](/docs/advanced/what-models) for the full breakdown.
 
 ## Can I use my Claude Pro or Max subscription with Codebuff?
 

--- a/web/src/content/help/faq.mdx
+++ b/web/src/content/help/faq.mdx
@@ -13,7 +13,7 @@ Software development: Writing features, tests, and scripts across common languag
 
 ## What model does Codebuff use?
 
-Multiple. The orchestrator uses Claude Opus 4.6 in Default and Max modes, or GLM 5.1 in Free mode. Subagents are matched to their tasks: Claude Opus 4.6 for code editing, GPT-5.1 for deep reasoning, Grok 4.1 Fast for terminal commands and research, and Relace AI for fast file rewrites. Free mode includes code review support. See [What models do you use?](/docs/advanced/what-models) for the full breakdown.
+Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or GLM 5.1 in Free mode. Subagents are matched to their tasks: Claude Opus 4.7 (with GLM 5.1 as a lighter option) for code editing, Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research. Free mode includes code review support. See [What models do you use?](/docs/advanced/what-models) for the full breakdown.
 
 ## Can I use my Claude Pro or Max subscription with Codebuff?
 

--- a/web/src/content/tips/modes.mdx
+++ b/web/src/content/tips/modes.mdx
@@ -12,15 +12,15 @@ Codebuff has four modes. Switch during a session with `Shift+Tab` or `/mode:` co
 <MarkdownTable>
   | Mode | Model | Editor Agent | Code Review |
   | --- | --- | --- | --- | --- |
-  | Default | Claude Opus 4.6 | editor | Yes |
-  | Max | Claude Opus 4.6 | editor-multi-prompt | Yes |
-  | Plan | Claude Opus 4.6 | None | No |
+  | Default | Claude Opus 4.7 | editor | Yes |
+  | Max | Claude Opus 4.7 | editor-multi-prompt | Yes |
+  | Plan | Claude Opus 4.7 | None | No |
   | Lite | GLM 5.1 | None | No |
 </MarkdownTable>
 
 ## Default
 
-Standard mode with Claude Opus 4.6:
+Standard mode with Claude Opus 4.7:
 
 - Spawns [file pickers](/publishers/codebuff/agents/file-picker) and [code searchers](/publishers/codebuff/agents/code-searcher) to gather context
 - Uses the [`editor`](/publishers/codebuff/agents/editor) agent for code changes
@@ -32,7 +32,7 @@ Switch to this mode with `/mode:default`.
 
 ## Max
 
-Claude Opus 4.6 with best-of-N selection:
+Claude Opus 4.7 with best-of-N selection:
 
 - Reads 12-20+ files per task
 - Spawns multiple [editor](/publishers/codebuff/agents/editor) agents in parallel, each with a different strategy


### PR DESCRIPTION
Hey guys!

The docs were still telling users that Codebuff runs on Claude Opus 4.6 and referenced a few subagent models/modes that no longer exist. This PR brings the docs back in sync with what the agents in agents/ actually use today.

## What changed

**Opus 4.6 → Opus 4.7** across all user-facing docs:

- `tips/modes.mdx` — mode table and Default/Max section text
- `advanced/what-models.mdx` — orchestrator table and subagent model list
- `advanced/claude-code-comparison.mdx` — orchestrator mention
- `advanced/how-does-it-work.mdx` — orchestrator mention, plus Thinker/Editor/Reviewer rows corrected to match the current agent definitions (Thinker: Opus 4.7 + GPT-5.4, Editor: Opus 4.7 + GPT-5.1 + GLM 5.1, Reviewer: Opus 4.7 + GLM 5.1 in Lite)

**FAQ answer rewrite** (`help/faq.mdx` and the mirrored SEO structured data in `web/src/app/docs/[category]/[slug]/page.tsx`):

- "Free mode" → "Lite mode" (Free was changed to Lite as I can see)
- Drop stale "GPT-5.1 for deep reasoning", "Grok 4.1 Fast for terminal commands and research", and "Relace AI for fast file rewrites" mentions — file writes are handled deterministically by the runtime (`packages/agent-runtime/src/process-file-block.ts`), and Relace is only used as a file-picker re-ranker in admin tooling, not for edits
- Replace with the current setup: Opus 4.7 + GPT-5.4 for reasoning/review, Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research

No behavior changes — docs only.

If some sentences don't sound right - please tell me, I'll update them.

Thanks! ❤️