### PR TITLE
Add .claude/settings.json with auto permission mode

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "defaultMode": "auto"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` to set the default Claude Code permission mode to `auto` for this repo.

## Test plan
- [ ] Verify Claude Code picks up `auto` mode when working in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)