### PR TITLE
Keep freebuff session alive when browsing /history

### DIFF
--- a/cli/src/app.tsx
+++ b/cli/src/app.tsx
@@ -285,17 +285,6 @@ export const App = ({
     )
   }
 
-  // Render chat history screen when requested
-  if (showChatHistory) {
-    return (
-      <ChatHistoryScreen
-        onSelectChat={handleResumeChat}
-        onCancel={closeChatHistory}
-        onNewChat={handleNewChat}
-      />
-    )
-  }
-
   // Use key to force remount when resuming a different chat from history
   const chatKey = resumeChatId ?? 'current'
 
@@ -316,6 +305,10 @@ export const App = ({
       initialMode={initialMode}
       gitRoot={gitRoot}
       onSwitchToGitRoot={handleSwitchToGitRoot}
+      showChatHistory={showChatHistory}
+      onSelectChat={handleResumeChat}
+      onCancelChatHistory={closeChatHistory}
+      onNewChat={handleNewChat}
     />
   )
 }
@@ -336,6 +329,10 @@ interface AuthedSurfaceProps {
   initialMode: AgentMode | undefined
   gitRoot: string | null | undefined
   onSwitchToGitRoot: () => void
+  showChatHistory: boolean
+  onSelectChat: (chatId: string) => void
+  onCancelChatHistory: () => void
+  onNewChat: () => void
 }
 
 /**
@@ -359,6 +356,10 @@ const AuthedSurface = ({
   initialMode,
   gitRoot,
   onSwitchToGitRoot,
+  showChatHistory,
+  onSelectChat,
+  onCancelChatHistory,
+  onNewChat,
 }: AuthedSurfaceProps) => {
   const { session, error: sessionError } = useFreebuffSession()
 
@@ -386,6 +387,20 @@ const AuthedSurface = ({
       session.status === 'none')
   ) {
     return <WaitingRoomScreen session={session} error={sessionError} />
+  }
+
+  // Chat history renders inside AuthedSurface so the freebuff session stays
+  // mounted while the user browses history. Unmounting this surface would
+  // DELETE the session row and drop the user back into the waiting room on
+  // return.
+  if (showChatHistory) {
+    return (
+      <ChatHistoryScreen
+        onSelectChat={onSelectChat}
+        onCancel={onCancelChatHistory}
+        onNewChat={onNewChat}
+      />
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- In freebuff, after admission from the waiting room, opening `/history` (and then selecting a chat or canceling) sent the user back to the waiting room.
- Cause: rendering `ChatHistoryScreen` at the `App` level unmounted `AuthedSurface`, which ran `useFreebuffSession` cleanup (DELETE + clear session). The next render POSTed again and landed in the waiting room.
- Fix: render `ChatHistoryScreen` inside `AuthedSurface` (after the freebuff gate) so the session stays mounted across history browsing.

## Test plan
- [ ] As a freebuff user, get admitted from the waiting room, run `/history`, select a previous chat — verify you land directly in the resumed chat and not back in the waiting room.
- [ ] Same flow, but cancel out of the history screen — verify you return to the current chat with session intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)