### PR TITLE
Estimate waiting room wait as 24 seconds per spot ahead

### DIFF
--- a/web/src/server/free-session/__tests__/session-view.test.ts
+++ b/web/src/server/free-session/__tests__/session-view.test.ts
@@ -4,7 +4,7 @@ import { estimateWaitMs, toSessionStateResponse } from '../session-view'
 
 import type { InternalSessionRow } from '../types'
 
-const WAIT_PER_SPOT_MS = 60_000
+const WAIT_PER_SPOT_MS = 24_000
 const GRACE_MS = 30 * 60_000
 
 function row(overrides: Partial<InternalSessionRow> = {}): InternalSessionRow {

--- a/web/src/server/free-session/session-view.ts
+++ b/web/src/server/free-session/session-view.ts
@@ -59,10 +59,10 @@ export function toSessionStateResponse(params: {
   return null
 }
 
-const WAIT_MS_PER_SPOT_AHEAD = 60_000
+const WAIT_MS_PER_SPOT_AHEAD = 24_000
 
 /**
- * Rough wait-time estimate shown to queued users: one minute per spot ahead.
+ * Rough wait-time estimate shown to queued users: 24 seconds per spot ahead.
  * Position 1 → 0ms (next tick picks you up).
  */
 export function estimateWaitMs(params: { position: number }): number {


### PR DESCRIPTION
Reduces the queued wait-time estimate from 60 seconds to 24 seconds (0.4 × 60) per spot ahead, better reflecting actual admission throughput. Updates the constant in `session-view.ts` and the matching test constant.