### PR TITLE
Fix freebuff grace-period hang where UI looks stuck streaming

### DIFF
--- a/cli/src/chat.tsx
+++ b/cli/src/chat.tsx
@@ -1473,15 +1473,17 @@ export const Chat = ({
         )}
 
         {reviewMode ? (
-          // Review takes precedence over the session-ended banner: during the
-          // grace window the agent may still be asking to run tools, and
-          // those approvals must be reachable for the run to finish.
+          // Review and ask_user take precedence over the session-ended banner:
+          // during the grace window the agent may still be asking to run tools
+          // or asking the user a question, and those approvals/answers must be
+          // reachable for the run to finish — otherwise the agent hangs
+          // waiting for input that can never be given.
           <ReviewScreen
             onSelectOption={handleReviewOptionSelect}
             onCustom={handleReviewCustom}
             onCancel={handleCloseReviewScreen}
           />
-        ) : isFreebuffSessionOver ? (
+        ) : isFreebuffSessionOver && !askUserState ? (
           <SessionEndedBanner
             isStreaming={isStreaming || isWaitingForResponse}
           />

--- a/cli/src/hooks/helpers/send-message.ts
+++ b/cli/src/hooks/helpers/send-message.ts
@@ -510,10 +510,16 @@ function handleFreebuffGateError(
   switch (kind) {
     case 'session_expired':
     case 'waiting_room_required':
-      // Our seat is gone mid-chat. Flip to `ended` instead of auto re-queuing:
-      // the Chat surface stays mounted so any in-flight agent work can finish
-      // under the server-side grace period, and the session-ended banner
-      // prompts the user to press Enter when they're ready to rejoin.
+      // Our seat is gone mid-chat. Finalize the AI message so its streaming
+      // indicator stops — otherwise `isComplete` stays false and the message
+      // keeps rendering a blinking cursor forever, making the user think the
+      // agent is still working even though the SessionEndedBanner is visible
+      // and actionable. Also disposes the batched-updater flush interval.
+      updater.markComplete()
+      // Flip to `ended` instead of auto re-queuing: the Chat surface stays
+      // mounted so any in-flight agent work can finish under the server-side
+      // grace period, and the session-ended banner prompts the user to press
+      // Enter when they're ready to rejoin.
       markFreebuffSessionEnded()
       return
     case 'waiting_room_queued':


### PR DESCRIPTION
## Summary

Two separate hang vectors after a freebuff session ends mid-run, both reported as "task keeps running then just hangs, only option is to close the terminal":

- **`handleFreebuffGateError` never finalized the AI message.** For \`session_expired\`/\`waiting_room_required\`, the handler only flipped session state, leaving \`isComplete: false\` on the in-flight message. The streaming cursor kept rendering and the batched-updater flush interval leaked — users saw an apparently still-streaming message next to the rejoin banner and waited indefinitely. Now calls \`updater.markComplete()\`.
- **\`ask_user\` was unreachable while the session-ended banner was up.** If the agent was mid-\`ask_user\` when the session ended, the banner replaced the ChatInputBar and hid the answer form, so the run was waiting on input that could never arrive. Chat.tsx now lets \`ask_user\` take precedence over the banner (same pattern as review mode).

## Test plan

- [ ] Run a freebuff session, wait for grace to expire mid-agent-run, verify the last AI message visibly finalizes and the rejoin banner is clearly actionable.
- [ ] Trigger an \`ask_user\` during grace period, verify the answer form is reachable and the agent can complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)