### PR TITLE
Fix banned user test to match new suspension message

### DIFF
--- a/docs/error-schema.md
+++ b/docs/error-schema.md
@@ -34,7 +34,7 @@ Used for errors that the client needs to identify programmatically:
 
 | Status | `error` code | Example `message` |
 |--------|-------------|-------------------|
-| 403 | `account_suspended` | `"Your account has been suspended due to billing issues. Please contact support@codebuff.com to resolve this."` |
+| 403 | `account_suspended` | `"Your account has been suspended. Please contact support@codebuff.com if you did not expect this."` |
 | 403 | `free_mode_unavailable` | `"Free mode is not available in your country."` (Freebuff: `"Freebuff is not available in your country."`) |
 | 429 | `rate_limit_exceeded` | `"Subscription weekly limit reached. Your limit resets in 2 hours. Enable 'Continue with credits' in the CLI to use a-la-carte credits."` |
 

--- a/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
+++ b/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
@@ -412,8 +412,8 @@ describe('/api/v1/chat/completions POST endpoint', () => {
       expect(response.status).toBe(403)
       const body = await response.json()
       expect(body.error).toBe('account_suspended')
-      expect(body.message).toContain('Your account has been suspended due to billing issues')
-      expect(body.message).toContain('to resolve this')
+      expect(body.message).toContain('Your account has been suspended')
+      expect(body.message).toContain('if you did not expect this')
     })
   })
 


### PR DESCRIPTION
## Summary
- The banned-user response message in `_post.ts` was updated, but the test assertions still checked the old phrasing ("due to billing issues" / "to resolve this").
- Updated `completions.test.ts` assertions to match the current message ("Your account has been suspended" / "if you did not expect this").
- Updated the example in `docs/error-schema.md` to reflect the new message.

## Test plan
- [ ] CI: `bun test web/src/app/api/v1/chat/completions/__tests__/completions.test.ts` passes the "Banned users" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)