### PR TITLE
Remove shimmer animation from freebuff waiting room Wait time

### DIFF
--- a/cli/src/components/waiting-room-screen.tsx
+++ b/cli/src/components/waiting-room-screen.tsx
@@ -190,13 +190,9 @@ export const WaitingRoomScreen: React.FC<WaitingRoomScreenProps> = ({
                 <text style={{ fg: theme.foreground, alignSelf: 'flex-start' }}>
                   <span fg={theme.muted}>Wait     </span>
                   <span fg={theme.primary}>
-                    <ShimmerText
-                      text={
-                        session.position === 1
-                          ? 'any moment now'
-                          : formatWait(session.estimatedWaitMs)
-                      }
-                    />
+                    {session.position === 1
+                      ? 'any moment now'
+                      : formatWait(session.estimatedWaitMs)}
                   </span>
                 </text>
                 <text style={{ fg: theme.muted, alignSelf: 'flex-start' }}>


### PR DESCRIPTION
Unwraps the `Wait` time value in the freebuff waiting room from `ShimmerText` so it renders as plain static text. The shimmering wait estimate read as flickering noise next to the static `Position` and `Elapsed` rows; the other shimmer (the "Joining the waiting room…" placeholder) is preserved.