### PR TITLE
Disable followup clicks after freebuff session ends

### DIFF
--- a/cli/src/components/tools/suggest-followups.tsx
+++ b/cli/src/components/tools/suggest-followups.tsx
@@ -5,6 +5,8 @@ import { defineToolComponent } from './types'
 import { useTerminalDimensions } from '../../hooks/use-terminal-dimensions'
 import { useTheme } from '../../hooks/use-theme'
 import { getLatestFollowupToolCallId, useChatStore } from '../../state/chat-store'
+import { useFreebuffSessionStore } from '../../state/freebuff-session-store'
+import { IS_FREEBUFF } from '../../utils/constants'
 import { Button } from '../button'
 
 import type { ToolRenderConfig } from './types'
@@ -223,6 +225,9 @@ const SuggestFollowupsItem = ({
 }: SuggestFollowupsItemProps) => {
   const theme = useTheme()
   const inputFocused = useChatStore((state) => state.inputFocused)
+  const isFreebuffSessionOver = useFreebuffSessionStore(
+    (state) => IS_FREEBUFF && state.session?.status === 'ended',
+  )
   const setSuggestedFollowups = useChatStore(
     (state) => state.setSuggestedFollowups,
   )
@@ -305,7 +310,7 @@ const SuggestFollowupsItem = ({
             isHovered={hoveredIndex === index}
             onSendFollowup={onSendFollowup}
             onHover={setHoveredIndex}
-            disabled={!inputFocused}
+            disabled={!inputFocused || isFreebuffSessionOver}
             labelColumnWidth={labelColumnWidth}
           />
         ))}


### PR DESCRIPTION
## Summary
After a freebuff session ends, the chat input is swapped out for a `SessionEndedBanner`, but the suggested-followup buttons from earlier in the transcript stayed clickable (the server grants a 30-minute grace period, so clicks still went through). This extends the `disabled` gate on `FollowupLine` to also cover `IS_FREEBUFF && session.status === 'ended'` — the same condition `chat.tsx` already uses to show the session-ended banner.

## Test plan
- [ ] Start a freebuff session, trigger suggested followups, end the session, and confirm the followup buttons no longer highlight on hover or respond to clicks
- [ ] Confirm followups still work normally in a non-freebuff (Codebuff) session and in an active freebuff session