### PR TITLE
Reward established GitHub accounts in freebuff bot-sweep scoring

### DIFF
--- a/web/src/server/free-session/abuse-detection.ts
+++ b/web/src/server/free-session/abuse-detection.ts
@@ -297,6 +297,17 @@ async function enrichWithGithubAge(
       } else if (ageDays < 90) {
         s.flags.push(`gh-new<90d:${ageDays.toFixed(0)}d`)
         s.score += 10
+      } else if (ageDays >= 365 * 3) {
+        // Established GitHub accounts are a strong counter-signal: buying
+        // a 3+ year old account is rare at our abuse scale. Subtract enough
+        // to pull a day-1 heavy user (new-acct<1d + very-heavy = 90) back
+        // below the high-tier threshold without fully clearing them —
+        // genuine 24/7 patterns still surface.
+        s.flags.push(`gh-established:${(ageDays / 365).toFixed(1)}y`)
+        s.score -= 40
+      } else if (ageDays >= 365) {
+        s.flags.push(`gh-established:${(ageDays / 365).toFixed(1)}y`)
+        s.score -= 20
       }
     }
   }

--- a/web/src/server/free-session/abuse-review.ts
+++ b/web/src/server/free-session/abuse-review.ts
@@ -41,6 +41,8 @@ You will see:
 
 A very young GitHub account (gh_age < 7d, especially < 1d) combined with heavy usage is one of the strongest bot signals we have: real developers almost never create a GitHub account on the same day they start running an agent. Weigh this heavily in tiering.
 
+Conversely, an established GitHub account (gh_age ≥ 1 year, especially ≥ 3 years) is a strong counter-signal. Account-age spoofing by buying old accounts is possible but uncommon at our abuse scale. An established GitHub + a natural agent mix (basher, code-reviewer, file-picker alongside the root agent) + some activity gaps during the day reads like an excited first-day power user, not a bot. Don't tier these as HIGH unless there's a second independent signal (creation cluster membership, true 24/7 distinct_hours, suspicious email pattern).
+
 Produce a markdown report with three sections:
 
 ## TIER 1 — HIGH CONFIDENCE (ban)


### PR DESCRIPTION
## Summary
- Investigation context: VenTheZone (kytusdevenn@gmail.com), a day-1 Codebuff user linked to a ~4-year-old GitHub (15 public repos, natural agent mix), scored 90 (high-tier) on volume + new-acct signals alone and got auto-banned. Unbanned out-of-band.
- Recalibrates \`abuse-detection.ts\`: subtract 20 for gh_age ≥ 1y, 40 for ≥ 3y. Pulls day-1 heavy users with established GitHubs into the medium tier unless a second independent signal (creation cluster, 24/7 distinct hours, suspicious email) also trips.
- Updates the \`abuse-review.ts\` reviewer prompt to weight the counter-signal symmetrically with the existing "young GitHub + heavy usage" warning.

## Test plan
- [ ] Next hourly bot-sweep email: check that established-GH users appear in MEDIUM, not HIGH, and that the LLM review doesn't tier them as ban candidates without a second signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)