### PR TITLE
Show project picker before auth/waiting-room gates

### DIFF
--- a/cli/src/app.tsx
+++ b/cli/src/app.tsx
@@ -260,6 +260,20 @@ export const App = ({
     // 4xx client errors (401, 403, etc.) keep 'ok' - network is fine, just auth failed
   }
 
+  // Render project picker FIRST when at home directory or outside a project.
+  // This deliberately precedes the login/auth and waiting-room gates so the
+  // user always gets to pick a working directory before anything else — auth
+  // failures or a banned/queued freebuff session would otherwise replace the
+  // picker mid-flash and look like being kicked out of the app.
+  if (showProjectPicker) {
+    return (
+      <ProjectPickerScreen
+        onSelectProject={onProjectChange}
+        initialPath={projectRoot}
+      />
+    )
+  }
+
   // Render login modal when not authenticated AND auth service is reachable
   // Don't show login modal during network outages OR while retrying
   if (
@@ -271,16 +285,6 @@ export const App = ({
       <LoginModal
         onLoginSuccess={handleLoginSuccess}
         hasInvalidCredentials={hasInvalidCredentials}
-      />
-    )
-  }
-
-  // Render project picker when at home directory or outside a project
-  if (showProjectPicker) {
-    return (
-      <ProjectPickerScreen
-        onSelectProject={onProjectChange}
-        initialPath={projectRoot}
       />
     )
   }


### PR DESCRIPTION
## Summary

When freebuff is launched from the home directory, the project picker briefly showed and was then replaced by the login modal (or, downstream, the waiting room / banned screen) — users read this as being "kicked out of the app." The login-modal gate sat in front of the picker check in `app.tsx`, so any `authQuery` failure (more likely since the recent banned-user / abuse-detector work) pre-empted the picker.

This reorders the render in `cli/src/app.tsx` so the project picker renders first when the user starts at home. Picking a directory flips `showProjectPicker` off and the normal auth → waiting-room → chat flow runs as before. The picker is pure UI with no auth dependencies, so rendering it before auth is safe.

## Test plan

- [x] Typecheck clean; `project-picker.test.ts` passes
- [x] Launched freebuff from `$HOME` in tmux — picker renders and stays
- [ ] Verify on a banned / revoked-token account that picker now shows first, then the downstream banned / login screen after a directory is selected