### PR TITLE
[codex] Raise MiniMax instant admit threshold

### DIFF
--- a/web/src/server/free-session/config.ts
+++ b/web/src/server/free-session/config.ts
@@ -49,7 +49,7 @@ export function getSessionGraceMs(): number {
  */
 const INSTANT_ADMIT_CAPACITY: Record<string, number> = {
   'z-ai/glm-5.1': 50,
-  'minimax/minimax-m2.7': 200,
+  'minimax/minimax-m2.7': 1000,
 }
 
 export function getInstantAdmitCapacity(id: string): number {


### PR DESCRIPTION
Raises the freebuff MiniMax M2.7 instant-admit capacity from 200 to 1000. This lets more MiniMax users skip the waiting room before FIFO backpressure starts. The change is limited to the server-side free-session config knob, so CLI-facing shared model definitions are unchanged. Validated with `bun test web/src/server/free-session/__tests__/config.test.ts` using dummy required env vars for config initialization.