### PR TITLE
[codex] Show ad title when ad URL is missing

### DIFF
--- a/cli/src/components/__tests__/choice-ad-banner.test.tsx
+++ b/cli/src/components/__tests__/choice-ad-banner.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getAdDisplayLabel } from '../choice-ad-banner'
+
+describe('choice ad banner display label', () => {
+  test('uses the display domain when the ad has a URL', () => {
+    expect(
+      getAdDisplayLabel({
+        title: 'Example Sponsor',
+        url: 'https://www.example.com/path',
+      }),
+    ).toEqual({ text: 'example.com', variant: 'domain' })
+  })
+
+  test('uses the ad title when the ad has no URL', () => {
+    expect(
+      getAdDisplayLabel({
+        title: 'Example Sponsor',
+        url: '',
+      }),
+    ).toEqual({ text: 'Example Sponsor', variant: 'title' })
+  })
+})

--- a/cli/src/components/choice-ad-banner.tsx
+++ b/cli/src/components/choice-ad-banner.tsx
@@ -28,7 +28,6 @@ function truncateToLines(text: string, lineWidth: number, maxLines: number): str
 function truncateToWidth(text: string, width: number): string {
   if (width <= 0) return ''
   if (text.length <= width) return text
-  if (width === 1) return '…'
   return text.slice(0, width - 1) + '…'
 }
 

--- a/cli/src/components/choice-ad-banner.tsx
+++ b/cli/src/components/choice-ad-banner.tsx
@@ -25,13 +25,31 @@ function truncateToLines(text: string, lineWidth: number, maxLines: number): str
   return text.slice(0, maxChars - 1) + '…'
 }
 
-const extractDomain = (url: string): string => {
+function truncateToWidth(text: string, width: number): string {
+  if (width <= 0) return ''
+  if (text.length <= width) return text
+  if (width === 1) return '…'
+  return text.slice(0, width - 1) + '…'
+}
+
+export const extractDomain = (url: string): string => {
   try {
     const parsed = new URL(url)
     return parsed.hostname.replace(/^www\./, '')
   } catch {
     return url
   }
+}
+
+export function getAdDisplayLabel(
+  ad: Pick<AdResponse, 'title' | 'url'>,
+): { text: string; variant: 'domain' | 'title' } {
+  const url = ad.url.trim()
+  if (url) {
+    return { text: extractDomain(url), variant: 'domain' }
+  }
+
+  return { text: ad.title.trim() || 'Sponsored', variant: 'title' }
 }
 
 /**
@@ -89,8 +107,10 @@ export const ChoiceAdBanner: React.FC<ChoiceAdBannerProps> = ({ ads, onImpressio
       >
         {visibleAds.map((ad, i) => {
           const isHovered = hoveredIndex === i
-          const domain = extractDomain(ad.url)
           const ctaText = ad.cta || ad.title || 'Learn more'
+          const label = getAdDisplayLabel(ad)
+          const labelMaxWidth = Math.max(0, widths[i] - ctaText.length - 5)
+          const labelText = truncateToWidth(label.text, labelMaxWidth)
 
           return (
             <Button
@@ -130,8 +150,16 @@ export const ChoiceAdBanner: React.FC<ChoiceAdBannerProps> = ({ ads, onImpressio
                 >
                   {` ${ctaText} `}
                 </text>
-                <text style={{ fg: theme.muted, attributes: TextAttributes.UNDERLINE }}>
-                  {domain}
+                <text
+                  style={{
+                    fg: theme.muted,
+                    attributes:
+                      label.variant === 'domain'
+                        ? TextAttributes.UNDERLINE
+                        : TextAttributes.DIM,
+                  }}
+                >
+                  {labelText}
                 </text>
 
               </box>


### PR DESCRIPTION
## Summary

- Show an ad title in the CLI choice ad banner when the normalized ad has no display URL.
- Keep URL-backed ads rendering their underlined display domain.
- Add a focused unit test for the display-label helper.

## Why

Carbon ads intentionally omit the display URL because their click URL is a tracking redirect. That left the banner's secondary label blank. Falling back to the title preserves useful advertiser context without showing the tracking host.

## Validation

- `bun test cli/src/components/__tests__/choice-ad-banner.test.tsx`
- `bun run --cwd cli typecheck`
