### PR TITLE
Use Kimi K2.6 for free and lite

### DIFF
--- a/.agents/types/agent-definition.ts
+++ b/.agents/types/agent-definition.ts
@@ -423,8 +423,7 @@ export type ModelName =
   // Other open source models
   | 'moonshotai/kimi-k2'
   | 'moonshotai/kimi-k2:nitro'
-  | 'moonshotai/kimi-k2.5'
-  | 'moonshotai/kimi-k2.5:nitro'
+  | 'moonshotai/kimi-k2.6'
   | 'z-ai/glm-5'
   | 'z-ai/glm-4.6'
   | 'z-ai/glm-4.6:nitro'

--- a/agents/__tests__/editor.test.ts
+++ b/agents/__tests__/editor.test.ts
@@ -5,9 +5,7 @@ import editor, { createCodeEditor } from '../editor/editor'
 import type { AgentState, ToolCall } from '../types/agent-definition'
 
 describe('editor agent', () => {
-  const createMockAgentState = (
-    messageHistory: any[] = [],
-  ): AgentState => ({
+  const createMockAgentState = (messageHistory: any[] = []): AgentState => ({
     agentId: 'editor-test',
     runId: 'test-run',
     parentId: undefined,
@@ -67,6 +65,11 @@ describe('editor agent', () => {
       expect(glmEditor.model).toBe('z-ai/glm-5.1')
     })
 
+    test('creates kimi editor', () => {
+      const kimiEditor = createCodeEditor({ model: 'kimi' })
+      expect(kimiEditor.model).toBe('moonshotai/kimi-k2.6')
+    })
+
     test('creates minimax editor', () => {
       const minimaxEditor = createCodeEditor({ model: 'minimax' })
       expect(minimaxEditor.model).toBe('minimax/minimax-m2.7')
@@ -82,6 +85,12 @@ describe('editor agent', () => {
       const glmEditor = createCodeEditor({ model: 'glm' })
       expect(glmEditor.instructionsPrompt).not.toContain('<think>')
       expect(glmEditor.instructionsPrompt).not.toContain('</think>')
+    })
+
+    test('kimi editor does not include think tags in instructions', () => {
+      const kimiEditor = createCodeEditor({ model: 'kimi' })
+      expect(kimiEditor.instructionsPrompt).not.toContain('<think>')
+      expect(kimiEditor.instructionsPrompt).not.toContain('</think>')
     })
 
     test('minimax editor does not include think tags in instructions', () => {
@@ -171,10 +180,10 @@ describe('editor agent', () => {
       ]
       const mockAgentState = createMockAgentState(initialMessages)
       const mockLogger = {
-        debug: () => { },
-        info: () => { },
-        warn: () => { },
-        error: () => { },
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
       }
 
       const generator = editor.handleSteps!({
@@ -194,10 +203,10 @@ describe('editor agent', () => {
       ]
       const mockAgentState = createMockAgentState(initialMessages)
       const mockLogger = {
-        debug: () => { },
-        info: () => { },
-        warn: () => { },
-        error: () => { },
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
       }
 
       const generator = editor.handleSteps!({
@@ -238,10 +247,10 @@ describe('editor agent', () => {
       ]
       const mockAgentState = createMockAgentState(initialMessages)
       const mockLogger = {
-        debug: () => { },
-        info: () => { },
-        warn: () => { },
-        error: () => { },
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
       }
 
       const generator = editor.handleSteps!({
@@ -271,7 +280,9 @@ describe('editor agent', () => {
         input: { output: { messages: any[] } }
       }
       expect(toolCall.input.output.messages).toHaveLength(3)
-      expect(toolCall.input.output.messages[0].content[0].text).toBe('Message 2')
+      expect(toolCall.input.output.messages[0].content[0].text).toBe(
+        'Message 2',
+      )
     })
 
     test('handleSteps can be serialized for sandbox execution', () => {
@@ -289,10 +300,10 @@ describe('editor agent', () => {
       const initialMessages: any[] = []
       const mockAgentState = createMockAgentState(initialMessages)
       const mockLogger = {
-        debug: () => { },
-        info: () => { },
-        warn: () => { },
-        error: () => { },
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
       }
 
       const generator = editor.handleSteps!({
@@ -303,7 +314,9 @@ describe('editor agent', () => {
 
       generator.next()
 
-      const newMessages = [{ role: 'assistant', content: [{ type: 'text', text: 'Done' }] }]
+      const newMessages = [
+        { role: 'assistant', content: [{ type: 'text', text: 'Done' }] },
+      ]
       const updatedState = createMockAgentState(newMessages)
 
       const result = generator.next({
@@ -316,7 +329,9 @@ describe('editor agent', () => {
         toolName: 'set_output',
         input: {
           output: {
-            messages: [{ role: 'assistant', content: [{ type: 'text', text: 'Done' }] }],
+            messages: [
+              { role: 'assistant', content: [{ type: 'text', text: 'Done' }] },
+            ],
           },
         },
         includeToolCall: false,
@@ -326,10 +341,10 @@ describe('editor agent', () => {
     test('works with empty initial message history', () => {
       const mockAgentState = createMockAgentState([])
       const mockLogger = {
-        debug: () => { },
-        info: () => { },
-        warn: () => { },
-        error: () => { },
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
       }
 
       const generator = editor.handleSteps!({
@@ -341,7 +356,10 @@ describe('editor agent', () => {
       generator.next()
 
       const newMessages = [
-        { role: 'assistant', content: [{ type: 'text', text: 'First response' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'First response' }],
+        },
       ]
       const updatedState = createMockAgentState(newMessages)
 

--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -30,7 +30,8 @@ export function createBase2(
 
   const isSonnet = false
   const model =
-    modelOverride ?? (isFree ? 'z-ai/glm-5.1' : 'anthropic/claude-opus-4.7')
+    modelOverride ??
+    (isFree ? 'moonshotai/kimi-k2.6' : 'anthropic/claude-opus-4.7')
   const defaultProviderOptions = isFree
     ? {
         data_collection: 'deny' as const,
@@ -110,11 +111,12 @@ export function createBase2(
 - **Spawn mentioned agents:** If the user uses "@AgentName" in their message, you must spawn that agent.
 - **Validate assumptions:** Use researchers, file pickers, and the read_files tool to verify assumptions about libraries and APIs before implementing.
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
-- **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.${noAskUser
+- **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.${
+      noAskUser
         ? ''
         : `
 - **Ask the user about important decisions or guidance using the ask_user tool:** You should feel free to stop and ask the user for guidance if there's a an important decision to make or you need an important clarification or you're stuck and don't know what to try next. Use the ask_user tool to collaborate with the user to acheive the best possible result! Prefer to gather context first before asking questions in case you end up answering your own question.`
-      }
+    }
 - **Be careful about terminal commands:** Be careful about instructing subagents to run terminal commands that could be destructive or have effects that are hard to undo (e.g. git push, git commit, running any scripts -- especially ones that could alter production environments (!), installing packages globally, etc). Don't run any of these effectful commands unless the user explicitly asks you to.
 - **Do what the user asks:** If the user asks you to do something, even running a risky terminal command, do it.
 - **Don't use set_output:** The set_output tool is for spawned subagents to report results. Don't use it yourself.
@@ -149,22 +151,23 @@ Use the spawn_agents tool to spawn specialized agents to help you complete the u
 - **Spawn multiple agents in parallel:** This increases the speed of your response **and** allows you to be more comprehensive by spawning more total agents to synthesize the best response.
 - **Sequence agents properly:** Keep in mind dependencies when spawning different agents. Don't spawn agents in parallel that depend on each other.
   ${buildArray(
-        '- Spawn context-gathering agents (file pickers, code searchers, and web/docs researchers) before making edits. Use the list_directory and glob tools directly for searching and exploring the codebase.',
-        isFree && 'Do not spawn the thinker-gpt agent, unless the user asks. Not everyone has connected their ChatGPT subscription to Codebuff to allow for it.',
-        isDefault &&
-        '- Spawn the editor agent to implement the changes after you have gathered all the context you need.',
-        (isDefault || isMax) &&
-        `- Spawn the ${isDefault ? 'thinker' : 'thinker-best-of-n-opus'} after gathering context to solve complex problems or when the user asks you to think about a problem. (gpt-5-agent is a last resort for complex problems)`,
-        isMax &&
-        `- IMPORTANT: You must spawn the editor-multi-prompt agent to implement the changes after you have gathered all the context you need. You must spawn this agent for non-trivial changes, since it writes much better code than you would with the str_replace or write_file tools. Don't spawn the editor in parallel with context-gathering agents.`,
-        isFree &&
-        '- Spawn a code-reviewer-lite to review the changes after you have implemented the changes.',
-        '- Spawn bashers sequentially if the second command depends on the the first.',
-        isDefault &&
-        '- Spawn a code-reviewer to review the changes after you have implemented the changes.',
-        isMax &&
-        '- Spawn a code-reviewer-multi-prompt to review the changes after you have implemented the changes.',
-      ).join('\n  ')}
+    '- Spawn context-gathering agents (file pickers, code searchers, and web/docs researchers) before making edits. Use the list_directory and glob tools directly for searching and exploring the codebase.',
+    isFree &&
+      'Do not spawn the thinker-gpt agent, unless the user asks. Not everyone has connected their ChatGPT subscription to Codebuff to allow for it.',
+    isDefault &&
+      '- Spawn the editor agent to implement the changes after you have gathered all the context you need.',
+    (isDefault || isMax) &&
+      `- Spawn the ${isDefault ? 'thinker' : 'thinker-best-of-n-opus'} after gathering context to solve complex problems or when the user asks you to think about a problem. (gpt-5-agent is a last resort for complex problems)`,
+    isMax &&
+      `- IMPORTANT: You must spawn the editor-multi-prompt agent to implement the changes after you have gathered all the context you need. You must spawn this agent for non-trivial changes, since it writes much better code than you would with the str_replace or write_file tools. Don't spawn the editor in parallel with context-gathering agents.`,
+    isFree &&
+      '- Spawn a code-reviewer-lite to review the changes after you have implemented the changes.',
+    '- Spawn bashers sequentially if the second command depends on the the first.',
+    isDefault &&
+      '- Spawn a code-reviewer to review the changes after you have implemented the changes.',
+    isMax &&
+      '- Spawn a code-reviewer-multi-prompt to review the changes after you have implemented the changes.',
+  ).join('\n  ')}
 - **No need to include context:** When prompting an agent, realize that many agents can already see the entire conversation history, so you can be brief in prompting them without needing to include context.
 - **Never spawn the context-pruner agent:** This agent is spawned automatically for you and you don't need to spawn it yourself.
 
@@ -183,19 +186,19 @@ For other questions, you can direct them to codebuff.com, or especially codebuff
 # Other response guidelines
 
 ${buildArray(
-        !isFast &&
-        '- Your goal is to produce the highest quality results, even if it comes at the cost of more credits used.',
-        !isFast && '- Speed is important, but a secondary goal.',
-        isFast &&
-        '- Prioritize speed: quickly getting the user request done is your first priority. Do not call any unnecessary tools. Spawn more agents in parallel to speed up the process. Be extremely concise in your responses. Use 2 words where you would have used 2 sentences.',
-        '- If a tool fails, try again, or try a different tool or approach.',
-        (isDefault || isMax) &&
-        '- **Use <think></think> tags for moderate reasoning:** When you need to work through something moderately complex (e.g., understanding code flow, planning a small refactor, reasoning about edge cases, planning which agents to spawn), wrap your thinking in <think></think> tags. Spawn the thinker agent for anything more complex.',
-        '- Context is managed for you. The context-pruner agent will automatically run as needed. Gather as much context as you need without worrying about it.',
-        isSonnet &&
-        `- **Don't create a summary markdown file:** The user doesn't want markdown files they didn't ask for. Don't create them.`,
-        '- **Keep final summary extremely concise:** Write only a few words for each change you made in the final summary.',
-      ).join('\n')}
+  !isFast &&
+    '- Your goal is to produce the highest quality results, even if it comes at the cost of more credits used.',
+  !isFast && '- Speed is important, but a secondary goal.',
+  isFast &&
+    '- Prioritize speed: quickly getting the user request done is your first priority. Do not call any unnecessary tools. Spawn more agents in parallel to speed up the process. Be extremely concise in your responses. Use 2 words where you would have used 2 sentences.',
+  '- If a tool fails, try again, or try a different tool or approach.',
+  (isDefault || isMax) &&
+    '- **Use <think></think> tags for moderate reasoning:** When you need to work through something moderately complex (e.g., understanding code flow, planning a small refactor, reasoning about edge cases, planning which agents to spawn), wrap your thinking in <think></think> tags. Spawn the thinker agent for anything more complex.',
+  '- Context is managed for you. The context-pruner agent will automatically run as needed. Gather as much context as you need without worrying about it.',
+  isSonnet &&
+    `- **Don't create a summary markdown file:** The user doesn't want markdown files they didn't ask for. Don't create them.`,
+  '- **Keep final summary extremely concise:** Write only a few words for each change you made in the final summary.',
+).join('\n')}
 
 # Response examples
 
@@ -210,34 +213,38 @@ ${buildArray(
 
 [ You spawn another file-picker and code-searcher to find more relevant files, and use glob tools ]
 
-[ You read a few other relevant files using the read_files tool ]${!noAskUser
+[ You read a few other relevant files using the read_files tool ]${
+      !noAskUser
         ? `\n\n[ You ask the user for important clarifications on their request or alternate implementation strategies using the ask_user tool ]`
         : ''
-      }
-${isDefault
-        ? `[ You implement the changes using the editor agent ]`
-        : isFast || isFree
-          ? '[ You implement the changes using the str_replace or write_file tools ]'
-          : '[ You implement the changes using the editor-multi-prompt agent ]'
-      }
+    }
+${
+  isDefault
+    ? `[ You implement the changes using the editor agent ]`
+    : isFast || isFree
+      ? '[ You implement the changes using the str_replace or write_file tools ]'
+      : '[ You implement the changes using the editor-multi-prompt agent ]'
+}
 
-${isDefault
-        ? `[ You spawn a code-reviewer, a basher to typecheck the changes, and another basher to run tests, all in parallel ]`
-        : isFree
-          ? `[ You spawn a code-reviewer-lite to review the changes, a basher to typecheck the local changes, a basher to typecheck the whole project, and another basher to run tests, all in parallel ]`
-          : isMax
-            ? `[  You spawn a basher to typecheck the changes, and another basher to run tests, in parallel. Then, you spawn a code-reviewer-multi-prompt to review the changes. ]`
-            : '[ You spawn a basher to typecheck the changes and another basher to run tests, all in parallel ]'
-      }
+${
+  isDefault
+    ? `[ You spawn a code-reviewer, a basher to typecheck the changes, and another basher to run tests, all in parallel ]`
+    : isFree
+      ? `[ You spawn a code-reviewer-lite to review the changes, a basher to typecheck the local changes, a basher to typecheck the whole project, and another basher to run tests, all in parallel ]`
+      : isMax
+        ? `[  You spawn a basher to typecheck the changes, and another basher to run tests, in parallel. Then, you spawn a code-reviewer-multi-prompt to review the changes. ]`
+        : '[ You spawn a basher to typecheck the changes and another basher to run tests, all in parallel ]'
+}
 
-${isDefault
-        ? `[ You fix the issues found by the code-reviewer and type/test errors ]`
-        : isFree
-          ? `[ You fix the issues found by the code-reviewer-lite and type/test errors ]`
-          : isMax
-            ? `[ You fix the issues found by the code-reviewer-multi-prompt and type/test errors ]`
-            : '[ You fix the issues found by the type/test errors and spawn more bashers to confirm ]'
-      }
+${
+  isDefault
+    ? `[ You fix the issues found by the code-reviewer and type/test errors ]`
+    : isFree
+      ? `[ You fix the issues found by the code-reviewer-lite and type/test errors ]`
+      : isMax
+        ? `[ You fix the issues found by the code-reviewer-multi-prompt and type/test errors ]`
+        : '[ You fix the issues found by the type/test errors and spawn more bashers to confirm ]'
+}
 
 [ All tests & typechecks pass -- you write a very short final summary of the changes you made ]
  </reponse>
@@ -268,25 +275,25 @@ ${PLACEHOLDER.GIT_CHANGES_PROMPT}
     instructionsPrompt: planOnly
       ? buildPlanOnlyInstructionsPrompt({})
       : buildImplementationInstructionsPrompt({
-        isSonnet,
-        isFast,
-        isDefault,
-        isMax,
-        isFree,
-        hasNoValidation,
-        noAskUser,
-      }),
+          isSonnet,
+          isFast,
+          isDefault,
+          isMax,
+          isFree,
+          hasNoValidation,
+          noAskUser,
+        }),
     stepPrompt: planOnly
       ? buildPlanOnlyStepPrompt({})
       : buildImplementationStepPrompt({
-        isDefault,
-        isFast,
-        isMax,
-        hasNoValidation,
-        isSonnet,
-        isFree,
-        noAskUser,
-      }),
+          isDefault,
+          isFast,
+          isMax,
+          hasNoValidation,
+          isSonnet,
+          isFree,
+          noAskUser,
+        }),
 
     // handleSteps is serialized via .toString() and re-eval'd, so closure
     // variables like `isFree` are not in scope at runtime. Pick the right
@@ -351,34 +358,34 @@ function buildImplementationInstructionsPrompt({
 The user asks you to implement a new feature. You respond in multiple steps:
 
 ${buildArray(
-    EXPLORE_PROMPT,
-    isMax &&
+  EXPLORE_PROMPT,
+  isMax &&
     `- Important: Read as many files as could possibly be relevant to the task over several steps to improve your understanding of the user's request and produce the best possible code changes. Find more examples within the codebase similar to the user's request, dependencies that help with understanding how things work, tests, etc. This is frequently 12-20 files, depending on the task.`,
-    !noAskUser &&
+  !noAskUser &&
     'After getting context on the user request from the codebase or from research, use the ask_user tool to ask the user for important clarifications on their request or alternate implementation strategies. You should skip this step if the choice is obvious -- only ask the user if you need their help making the best choice.',
-    (isDefault || isMax || isFree) &&
+  (isDefault || isMax || isFree) &&
     `- For any task requiring 3+ steps, use the write_todos tool to write out your step-by-step implementation plan. Include ALL of the applicable tasks in the list.${isFast ? '' : ' You should include a step to review the changes after you have implemented the changes.'}:${hasNoValidation ? '' : ' You should include at least one step to validate/test your changes: be specific about whether to typecheck, run tests, run lints, etc.'} You may be able to do reviewing and validation in parallel in the same step. Skip write_todos for simple tasks like quick edits or answering questions.`,
-    (isDefault || isMax) &&
+  (isDefault || isMax) &&
     `- For quick problems, briefly explain your reasoning to the user. If you need to think longer, write your thoughts within the <think> tags. Finally, for complex problems, spawn the thinker agent to help find the best solution. (gpt-5-agent is a last resort for complex problems)`,
-    isDefault &&
+  isDefault &&
     '- IMPORTANT: You must spawn the editor agent to implement the changes after you have gathered all the context you need. This agent will do the best job of implementing the changes so you must spawn it for all non-trivial changes. Do not pass any prompt or params to the editor agent when spawning it. It will make its own best choices of what to do.',
-    isMax &&
+  isMax &&
     `- IMPORTANT: You must spawn the editor-multi-prompt agent to implement non-trivial code changes, since it will generate the best code changes from multiple implementation proposals. This is the best way to make high quality code changes -- strongly prefer using this agent over the str_replace or write_file tools, unless the change is very straightforward and obvious. You should also prompt it to implement the full task rather than just a single step.`,
-    isFast &&
+  isFast &&
     '- Implement the changes using the str_replace or write_file tools. Implement all the changes in one go.',
-    isFast &&
+  isFast &&
     '- Do a single typecheck targeted for your changes at most (if applicable for the project). Or skip this step if the change was small.',
-    !hasNoValidation &&
+  !hasNoValidation &&
     `- For non-trivial changes, test them by running appropriate validation commands for the project (e.g. typechecks, tests, lints, etc.). Try to run all appropriate commands in parallel. ${isMax ? ' Typecheck and test the specific area of the project that you are editing *AND* then typecheck and test the entire project if necessary.' : ' If you can, only test the area of the project that you are editing, rather than the entire project.'} You may have to explore the project to find the appropriate commands. Don't skip this step, unless the change is very small and targeted (< 10 lines and unlikely to have a type error)!`,
-    (isDefault || isMax) &&
+  (isDefault || isMax) &&
     `- Spawn a ${isDefault ? 'code-reviewer' : 'code-reviewer-multi-prompt'} to review the changes after you have implemented changes. (Skip this step only if the change is extremely straightforward and obvious.)`,
-    isFree &&
+  isFree &&
     `- Spawn a code-reviewer-lite to review the changes after you have implemented changes. (Skip this step only if the change is extremely straightforward and obvious.)`,
-    `- Inform the user that you have completed the task in one sentence or a few short bullet points.${isSonnet ? " Don't create any markdown summary files or example documentation files, unless asked by the user." : ''}`,
-    !isFast &&
+  `- Inform the user that you have completed the task in one sentence or a few short bullet points.${isSonnet ? " Don't create any markdown summary files or example documentation files, unless asked by the user." : ''}`,
+  !isFast &&
     !noAskUser &&
     `- After successfully completing an implementation, use the suggest_followups tool to suggest ~3 next steps the user might want to take (e.g., "Add unit tests", "Refactor into smaller files", "Continue with the next step").`,
-  ).join('\n')}`
+).join('\n')}`
 }
 
 function buildImplementationStepPrompt({
@@ -400,22 +407,22 @@ function buildImplementationStepPrompt({
 }) {
   return buildArray(
     isMax &&
-    `Keep working until the user's request is completely satisfied${!hasNoValidation ? ' and validated' : ''}, or until you require more information from the user.`,
+      `Keep working until the user's request is completely satisfied${!hasNoValidation ? ' and validated' : ''}, or until you require more information from the user.`,
     'Consider loading relevant skills with the skill tool if they might help with the current task. Do not reload skills that were already loaded earlier in this conversation.',
     isMax &&
-    `You must spawn the 'editor-multi-prompt' agent to implement code changes rather than using the str_replace or write_file tools, since it will generate the best code changes.`,
+      `You must spawn the 'editor-multi-prompt' agent to implement code changes rather than using the str_replace or write_file tools, since it will generate the best code changes.`,
     (isDefault || isMax) &&
-    `You must spawn a ${isDefault ? 'code-reviewer' : 'code-reviewer-multi-prompt'} to review the changes after you have implemented the changes and in parallel with typechecking or testing.`,
+      `You must spawn a ${isDefault ? 'code-reviewer' : 'code-reviewer-multi-prompt'} to review the changes after you have implemented the changes and in parallel with typechecking or testing.`,
     isFree &&
-    `You must spawn a code-reviewer-lite to review the changes after you have implemented the changes and in parallel with typechecking or testing.`,
+      `You must spawn a code-reviewer-lite to review the changes after you have implemented the changes and in parallel with typechecking or testing.`,
     `After completing the user request, summarize your changes in a sentence${isFast ? '' : ' or a few short bullet points'}.${isSonnet ? " Don't create any summary markdown files or example documentation files, unless asked by the user." : ''}.`,
     !isFast &&
-    !noAskUser &&
-    `At the end of your turn, you must use the suggest_followups tool to suggest around 3 next steps the user might want to take even if the user just asks a question.`,
+      !noAskUser &&
+      `At the end of your turn, you must use the suggest_followups tool to suggest around 3 next steps the user might want to take even if the user just asks a question.`,
   ).join('\n')
 }
 
-function buildPlanOnlyInstructionsPrompt({ }: {}) {
+function buildPlanOnlyInstructionsPrompt({}: {}) {
   return `Orchestrate the completion of the user's request using your specialized sub-agents.
 
  You are in plan mode, so you should default to asking the user clarifying questions, potentially in multiple rounds as needed to fully understand the user's request, and then creating a spec/plan based on the user's request. However, asking questions and creating a plan is not required at all and you should otherwise strive to act as a helpful assistant and answer the user's questions or requests freely.
@@ -425,8 +432,8 @@ function buildPlanOnlyInstructionsPrompt({ }: {}) {
 The user asks you to implement a new feature. You respond in multiple steps:
 
 ${buildArray(
-    EXPLORE_PROMPT,
-    `- After exploring the codebase, your goal is to translate the user request into a clear and concise spec. If the user is just asking a question, you can answer it instead of writing a spec.
+  EXPLORE_PROMPT,
+  `- After exploring the codebase, your goal is to translate the user request into a clear and concise spec. If the user is just asking a question, you can answer it instead of writing a spec.
 
 ## Asking questions
 
@@ -455,10 +462,10 @@ It should not include:
 
 This is more like an extremely short PRD which describes the end result of what the user wants. Think of it like fleshing out the user's prompt to make it more precise, although it should be as short as possible.
 `,
-  ).join('\n')}`
+).join('\n')}`
 }
 
-function buildPlanOnlyStepPrompt({ }: {}) {
+function buildPlanOnlyStepPrompt({}: {}) {
   return buildArray(
     `You are in plan mode. Do not make any file changes. Do not call write_file or str_replace. Do not use the write_todos tool.`,
   ).join('\n')

--- a/agents/editor/editor-lite.ts
+++ b/agents/editor/editor-lite.ts
@@ -3,7 +3,7 @@ import { createCodeEditor } from './editor'
 import type { AgentDefinition } from '../types/agent-definition'
 
 const definition: AgentDefinition = {
-  ...createCodeEditor({ model: 'glm' }),
+  ...createCodeEditor({ model: 'kimi' }),
   id: 'editor-lite',
 }
 export default definition

--- a/agents/editor/editor.ts
+++ b/agents/editor/editor.ts
@@ -1,10 +1,9 @@
-
 import { publisher } from '../constants'
 
 import type { AgentDefinition } from '../types/agent-definition'
 
 export const createCodeEditor = (options: {
-  model: 'gpt-5' | 'opus' | 'glm' | 'minimax'
+  model: 'gpt-5' | 'opus' | 'glm' | 'kimi' | 'minimax'
 }): Omit<AgentDefinition, 'id'> => {
   const { model } = options
   return {
@@ -14,9 +13,11 @@ export const createCodeEditor = (options: {
         ? 'openai/gpt-5.1'
         : options.model === 'minimax'
           ? 'minimax/minimax-m2.7'
-        : options.model === 'glm'
-          ? 'z-ai/glm-5.1'
-          : 'anthropic/claude-opus-4.7',
+          : options.model === 'kimi'
+            ? 'moonshotai/kimi-k2.6'
+            : options.model === 'glm'
+              ? 'z-ai/glm-5.1'
+              : 'anthropic/claude-opus-4.7',
     ...(options.model === 'opus' && {
       providerOptions: {
         only: ['amazon-bedrock'],
@@ -67,9 +68,13 @@ OR for new files or major rewrites:
 }
 </codebuff_tool_call>
 
-${model === 'gpt-5' || model === 'glm' || model === 'minimax'
-        ? ''
-        : `Before you start writing your implementation, you should use <think> tags to think about the best way to implement the changes.
+${
+  model === 'gpt-5' ||
+  model === 'glm' ||
+  model === 'kimi' ||
+  model === 'minimax'
+    ? ''
+    : `Before you start writing your implementation, you should use <think> tags to think about the best way to implement the changes.
 
 You can also use <think> tags interspersed between tool calls to think about the best way to implement the changes.
 
@@ -96,7 +101,7 @@ You can also use <think> tags interspersed between tool calls to think about the
 </codebuff_tool_call>
 
 </example>`
-      }
+}
 
 Your implementation should:
 - Be complete and comprehensive

--- a/agents/reviewer/code-reviewer-lite.ts
+++ b/agents/reviewer/code-reviewer-lite.ts
@@ -5,7 +5,7 @@ import { createReviewer } from './code-reviewer'
 const definition: SecretAgentDefinition = {
   id: 'code-reviewer-lite',
   publisher,
-  ...createReviewer('z-ai/glm-5.1'),
+  ...createReviewer('moonshotai/kimi-k2.6'),
 }
 
 export default definition

--- a/agents/types/agent-definition.ts
+++ b/agents/types/agent-definition.ts
@@ -423,6 +423,7 @@ export type ModelName =
   // Other open source models
   | 'moonshotai/kimi-k2'
   | 'moonshotai/kimi-k2:nitro'
+  | 'moonshotai/kimi-k2.6'
   | 'z-ai/glm-5'
   | 'z-ai/glm-5.1'
   | 'z-ai/glm-4.6'

--- a/cli/src/components/freebuff-model-selector.tsx
+++ b/cli/src/components/freebuff-model-selector.tsx
@@ -6,7 +6,7 @@ import { Button } from './button'
 import {
   FALLBACK_FREEBUFF_MODEL_ID,
   FREEBUFF_GEMINI_PRO_MODEL_ID,
-  FREEBUFF_GLM_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
   FREEBUFF_MODELS,
   getFreebuffDeploymentAvailabilityLabel,
   isFreebuffModelAvailable,
@@ -29,11 +29,11 @@ const FREEBUFF_MODEL_SELECTOR_MODELS = [
   ...FREEBUFF_MODELS.filter(
     (model) => model.id === FREEBUFF_GEMINI_PRO_MODEL_ID,
   ),
-  ...FREEBUFF_MODELS.filter((model) => model.id === FREEBUFF_GLM_MODEL_ID),
+  ...FREEBUFF_MODELS.filter((model) => model.id === FREEBUFF_KIMI_MODEL_ID),
   ...FREEBUFF_MODELS.filter(
     (model) =>
       model.id !== FREEBUFF_GEMINI_PRO_MODEL_ID &&
-      model.id !== FREEBUFF_GLM_MODEL_ID,
+      model.id !== FREEBUFF_KIMI_MODEL_ID,
   ),
 ]
 
@@ -80,7 +80,7 @@ export const FreebuffModelSelector: React.FC = () => {
     // unavailable (e.g. deployment hours close while the picker is open),
     // swap to the always-available fallback so Enter doesn't POST a model
     // the server will immediately reject. In-memory only — the user's saved
-    // preference (e.g. GLM) is preserved for the next launch.
+    // preference (e.g. Kimi) is preserved for the next launch.
     if (
       (session?.status === 'none' || !session) &&
       !isFreebuffModelAvailable(selectedModel, new Date(now))

--- a/cli/src/components/waiting-room-screen.tsx
+++ b/cli/src/components/waiting-room-screen.tsx
@@ -260,7 +260,7 @@ export const WaitingRoomScreen: React.FC<WaitingRoomScreenProps> = ({
                   <span>Elapsed </span>
                   {formatElapsed(elapsedMs)}
                 </text>
-                {/* Per-model session quota (e.g. GLM 5.1 caps at 5/12h). Only
+                {/* Per-model session quota (e.g. Kimi K2.6 caps at 5/12h). Only
                     rendered for rate-limited models so the Minimax queue stays
                     clutter-free. */}
                 {session.rateLimit && (
@@ -343,7 +343,7 @@ export const WaitingRoomScreen: React.FC<WaitingRoomScreenProps> = ({
             </>
           )}
 
-          {/* Per-model session quota exhausted (e.g. 5+ GLM sessions in the
+          {/* Per-model session quota exhausted (e.g. 5+ Kimi sessions in the
               last 12h). Terminal for this run — the user can exit and come
               back once the oldest session in the window rolls off. */}
           {session?.status === 'rate_limited' && (

--- a/cli/src/hooks/use-freebuff-session.ts
+++ b/cli/src/hooks/use-freebuff-session.ts
@@ -104,7 +104,7 @@ async function callSession(
       return body
     }
   }
-  // 429 from POST is the per-model session-quota reject (e.g. too many GLM
+  // 429 from POST is the per-model session-quota reject (e.g. too many Kimi
   // sessions in the last 12h). Terminal for the current poll — the CLI shows
   // a screen explaining the limit and when the user can try again. The 429
   // status (rather than 200) keeps older CLIs in their error path so they
@@ -442,9 +442,9 @@ export function useFreebuffSession(): UseFreebuffSessionResult {
         }
         if (next.status === 'model_unavailable') {
           // Server says the requested model isn't available right now (e.g.
-          // GLM outside deployment hours). Flip to the always-available
+          // Kimi outside deployment hours). Flip to the always-available
           // fallback for this run. In-memory only — `setSelectedModel`
-          // doesn't persist, so the user's saved preference (e.g. GLM)
+          // doesn't persist, so the user's saved preference (e.g. Kimi)
           // is preserved for their next launch during deployment hours.
           useFreebuffModelStore
             .getState()

--- a/common/src/__tests__/freebuff-models.test.ts
+++ b/common/src/__tests__/freebuff-models.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  DEFAULT_FREEBUFF_MODEL_ID,
   FREEBUFF_GEMINI_PRO_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
   FREEBUFF_MODELS,
   getFreebuffDeploymentAvailabilityLabel,
   isFreebuffDeploymentHours,
@@ -25,6 +27,10 @@ describe('freebuff model availability', () => {
         new Date('2026-01-05T12:00:00Z'),
       ),
     ).toBe(true)
+  })
+
+  test('defaults to Kimi K2.6', () => {
+    expect(DEFAULT_FREEBUFF_MODEL_ID).toBe(FREEBUFF_KIMI_MODEL_ID)
   })
 
   test('formats the close time in the user local timezone while deployment is open', () => {

--- a/common/src/__tests__/freebuff-models.test.ts
+++ b/common/src/__tests__/freebuff-models.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, test } from 'bun:test'
 import {
   DEFAULT_FREEBUFF_MODEL_ID,
   FREEBUFF_GEMINI_PRO_MODEL_ID,
+  FREEBUFF_GLM_MODEL_ID,
   FREEBUFF_KIMI_MODEL_ID,
   FREEBUFF_MODELS,
+  SUPPORTED_FREEBUFF_MODELS,
   getFreebuffDeploymentAvailabilityLabel,
   isFreebuffDeploymentHours,
+  isFreebuffModelId,
   isFreebuffModelAvailable,
+  isSupportedFreebuffModelId,
 } from '../constants/freebuff-models'
 
 describe('freebuff model availability', () => {
@@ -31,6 +35,17 @@ describe('freebuff model availability', () => {
 
   test('defaults to Kimi K2.6', () => {
     expect(DEFAULT_FREEBUFF_MODEL_ID).toBe(FREEBUFF_KIMI_MODEL_ID)
+  })
+
+  test('supports GLM 5.1 as a legacy server-side model without selecting it for new clients', () => {
+    expect(FREEBUFF_MODELS.map((model) => model.id)).not.toContain(
+      FREEBUFF_GLM_MODEL_ID,
+    )
+    expect(SUPPORTED_FREEBUFF_MODELS.map((model) => model.id)).toContain(
+      FREEBUFF_GLM_MODEL_ID,
+    )
+    expect(isFreebuffModelId(FREEBUFF_GLM_MODEL_ID)).toBe(false)
+    expect(isSupportedFreebuffModelId(FREEBUFF_GLM_MODEL_ID)).toBe(true)
   })
 
   test('formats the close time in the user local timezone while deployment is open', () => {

--- a/common/src/constants/free-agents.ts
+++ b/common/src/constants/free-agents.ts
@@ -1,6 +1,6 @@
 import { parseAgentId } from '../util/agent-id-parsing'
 
-import { FREEBUFF_MODELS } from './freebuff-models'
+import { SUPPORTED_FREEBUFF_MODELS } from './freebuff-models'
 
 import type { CostMode } from './model-config'
 
@@ -20,7 +20,9 @@ export const FREEBUFF_ROOT_AGENT_IDS = ['base2-free'] as const
 const FREEBUFF_ROOT_AGENT_ID_SET: ReadonlySet<string> = new Set(
   FREEBUFF_ROOT_AGENT_IDS,
 )
-const FREEBUFF_SELECTABLE_MODEL_IDS = FREEBUFF_MODELS.map((model) => model.id)
+const FREEBUFF_ALLOWED_MODEL_IDS = SUPPORTED_FREEBUFF_MODELS.map(
+  (model) => model.id,
+)
 
 /**
  * Agents that are allowed to run in FREE mode.
@@ -32,7 +34,7 @@ const FREEBUFF_SELECTABLE_MODEL_IDS = FREEBUFF_MODELS.map((model) => model.id)
  */
 export const FREE_MODE_AGENT_MODELS: Record<string, Set<string>> = {
   // Root orchestrator
-  'base2-free': new Set(FREEBUFF_SELECTABLE_MODEL_IDS),
+  'base2-free': new Set(FREEBUFF_ALLOWED_MODEL_IDS),
 
   // File exploration agents
   'file-picker': new Set(['google/gemini-2.5-flash-lite']),
@@ -44,13 +46,13 @@ export const FREE_MODE_AGENT_MODELS: Record<string, Set<string>> = {
   'researcher-docs': new Set(['google/gemini-3.1-flash-lite-preview']),
 
   // Command execution
-  'basher': new Set(['google/gemini-3.1-flash-lite-preview']),
+  basher: new Set(['google/gemini-3.1-flash-lite-preview']),
 
   // Editor for free mode
-  'editor-lite': new Set(FREEBUFF_SELECTABLE_MODEL_IDS),
+  'editor-lite': new Set(FREEBUFF_ALLOWED_MODEL_IDS),
 
   // Code reviewer for free mode
-  'code-reviewer-lite': new Set(FREEBUFF_SELECTABLE_MODEL_IDS),
+  'code-reviewer-lite': new Set(FREEBUFF_ALLOWED_MODEL_IDS),
 }
 
 /**

--- a/common/src/constants/freebuff-models.ts
+++ b/common/src/constants/freebuff-models.ts
@@ -22,6 +22,7 @@ export interface FreebuffModelOption {
  *  `getFreebuffDeploymentAvailabilityLabel()` instead. */
 export const FREEBUFF_DEPLOYMENT_HOURS_LABEL = '9am ET-5pm PT every day'
 export const FREEBUFF_GEMINI_PRO_MODEL_ID = 'google/gemini-3.1-pro-preview'
+export const FREEBUFF_GLM_MODEL_ID = 'z-ai/glm-5.1'
 export const FREEBUFF_KIMI_MODEL_ID = 'moonshotai/kimi-k2.6'
 export const FREEBUFF_MINIMAX_MODEL_ID = 'minimax/minimax-m2.7'
 const FREEBUFF_EASTERN_TIMEZONE = 'America/New_York'
@@ -61,7 +62,23 @@ export const FREEBUFF_MODELS = [
   },
 ] as const satisfies readonly FreebuffModelOption[]
 
+export const LEGACY_FREEBUFF_MODELS = [
+  {
+    id: FREEBUFF_GLM_MODEL_ID,
+    displayName: 'GLM 5.1',
+    tagline: 'Legacy',
+    availability: 'deployment_hours',
+  },
+] as const satisfies readonly FreebuffModelOption[]
+
+export const SUPPORTED_FREEBUFF_MODELS = [
+  ...FREEBUFF_MODELS,
+  ...LEGACY_FREEBUFF_MODELS,
+] as const satisfies readonly FreebuffModelOption[]
+
 export type FreebuffModelId = (typeof FREEBUFF_MODELS)[number]['id']
+export type SupportedFreebuffModelId =
+  (typeof SUPPORTED_FREEBUFF_MODELS)[number]['id']
 
 /** What new freebuff users see selected in the picker. May not be currently
  *  available (Kimi is closed outside deployment hours); callers that need an
@@ -89,9 +106,22 @@ export function resolveFreebuffModel(
   return isFreebuffModelId(id) ? id : FALLBACK_FREEBUFF_MODEL_ID
 }
 
+export function isSupportedFreebuffModelId(
+  id: string | null | undefined,
+): id is SupportedFreebuffModelId {
+  if (!id) return false
+  return SUPPORTED_FREEBUFF_MODELS.some((m) => m.id === id)
+}
+
+export function resolveSupportedFreebuffModel(
+  id: string | null | undefined,
+): SupportedFreebuffModelId {
+  return isSupportedFreebuffModelId(id) ? id : FALLBACK_FREEBUFF_MODEL_ID
+}
+
 export function getFreebuffModel(id: string): FreebuffModelOption {
   return (
-    FREEBUFF_MODELS.find((m) => m.id === id) ??
+    SUPPORTED_FREEBUFF_MODELS.find((m) => m.id === id) ??
     FREEBUFF_MODELS.find((m) => m.id === FALLBACK_FREEBUFF_MODEL_ID)!
   )
 }
@@ -242,7 +272,7 @@ export function isFreebuffModelAvailable(
   id: string,
   now: Date = new Date(),
 ): boolean {
-  const model = FREEBUFF_MODELS.find((m) => m.id === id)
+  const model = SUPPORTED_FREEBUFF_MODELS.find((m) => m.id === id)
   if (!model) return false
   return model.availability === 'always' || isFreebuffDeploymentHours(now)
 }

--- a/common/src/constants/freebuff-models.ts
+++ b/common/src/constants/freebuff-models.ts
@@ -22,7 +22,7 @@ export interface FreebuffModelOption {
  *  `getFreebuffDeploymentAvailabilityLabel()` instead. */
 export const FREEBUFF_DEPLOYMENT_HOURS_LABEL = '9am ET-5pm PT every day'
 export const FREEBUFF_GEMINI_PRO_MODEL_ID = 'google/gemini-3.1-pro-preview'
-export const FREEBUFF_GLM_MODEL_ID = 'z-ai/glm-5.1'
+export const FREEBUFF_KIMI_MODEL_ID = 'moonshotai/kimi-k2.6'
 export const FREEBUFF_MINIMAX_MODEL_ID = 'minimax/minimax-m2.7'
 const FREEBUFF_EASTERN_TIMEZONE = 'America/New_York'
 const FREEBUFF_PACIFIC_TIMEZONE = 'America/Los_Angeles'
@@ -54,8 +54,8 @@ export const FREEBUFF_MODELS = [
     availability: 'always',
   },
   {
-    id: FREEBUFF_GLM_MODEL_ID,
-    displayName: 'GLM 5.1',
+    id: FREEBUFF_KIMI_MODEL_ID,
+    displayName: 'Kimi K2.6',
     tagline: 'Smartest',
     availability: 'deployment_hours',
   },
@@ -64,15 +64,15 @@ export const FREEBUFF_MODELS = [
 export type FreebuffModelId = (typeof FREEBUFF_MODELS)[number]['id']
 
 /** What new freebuff users see selected in the picker. May not be currently
- *  available (GLM is closed outside deployment hours); callers that need an
+ *  available (Kimi is closed outside deployment hours); callers that need an
  *  always-available id for resolution / auto-fallbacks should use
  *  FALLBACK_FREEBUFF_MODEL_ID instead. */
-export const DEFAULT_FREEBUFF_MODEL_ID: FreebuffModelId = FREEBUFF_GLM_MODEL_ID
+export const DEFAULT_FREEBUFF_MODEL_ID: FreebuffModelId = FREEBUFF_KIMI_MODEL_ID
 
 /** Always-available fallback used when the requested model can't be served
  *  right now (unknown id, deployment hours closed, etc.). Kept distinct from
  *  DEFAULT_FREEBUFF_MODEL_ID so a new user's "preferred default" can be the
- *  smartest model without auto-flipping anyone to a closed deployment. */
+ *  smartest model without auto-flipping anyone to a closed serverless model. */
 export const FALLBACK_FREEBUFF_MODEL_ID: FreebuffModelId =
   FREEBUFF_MINIMAX_MODEL_ID
 

--- a/common/src/templates/initial-agents-dir/types/agent-definition.ts
+++ b/common/src/templates/initial-agents-dir/types/agent-definition.ts
@@ -423,6 +423,7 @@ export type ModelName =
   // Other open source models
   | 'moonshotai/kimi-k2'
   | 'moonshotai/kimi-k2:nitro'
+  | 'moonshotai/kimi-k2.6'
   | 'z-ai/glm-5'
   | 'z-ai/glm-5.1'
   | 'z-ai/glm-4.6'

--- a/common/src/types/freebuff-session.ts
+++ b/common/src/types/freebuff-session.ts
@@ -130,7 +130,7 @@ export type FreebuffSessionServerResponse =
       /** User has an active session bound to a different model. Returned
        *  from POST /session when they pick a new model without ending their
        *  current session first. The CLI shows a confirmation prompt: "End
-       *  your active GLM session to switch?" → on confirm, DELETE then
+       *  your active Kimi session to switch?" → on confirm, DELETE then
        *  re-POST with the new model. */
       status: 'model_locked'
       currentModel: string

--- a/freebuff/README.md
+++ b/freebuff/README.md
@@ -38,23 +38,23 @@ freebuff
 
 ## Commands
 
-| Command | Description |
-|---|---|
-| `/help` | Show keyboard shortcuts and tips |
-| `/new` | Start a new conversation |
-| `/history` | Browse past conversations |
-| `/bash` | Enter bash mode |
-| `/init` | Create a starter knowledge.md |
-| `/feedback` | Share feedback |
-| `/theme:toggle` | Toggle light/dark mode |
-| `/logout` | Sign out |
-| `/exit` | Quit |
+| Command         | Description                      |
+| --------------- | -------------------------------- |
+| `/help`         | Show keyboard shortcuts and tips |
+| `/new`          | Start a new conversation         |
+| `/history`      | Browse past conversations        |
+| `/bash`         | Enter bash mode                  |
+| `/init`         | Create a starter knowledge.md    |
+| `/feedback`     | Share feedback                   |
+| `/theme:toggle` | Toggle light/dark mode           |
+| `/logout`       | Sign out                         |
+| `/exit`         | Quit                             |
 
 ## FAQ
 
 **How can it be free?** Freebuff is supported by ads shown in the CLI.
 
-**What models do you use?** GLM 5.1 as the main coding agent, Gemini 3.1 Flash Lite for finding files and research, and GPT-5.4 for deep thinking if you connect your ChatGPT subscription.
+**What models do you use?** Kimi K2.6 as the main coding agent, Gemini 3.1 Flash Lite for finding files and research, and GPT-5.4 for deep thinking if you connect your ChatGPT subscription.
 
 **Are you training on my data?** No. We only use model providers that do not train on our requests. Your code stays yours.
 

--- a/freebuff/SPEC.md
+++ b/freebuff/SPEC.md
@@ -25,17 +25,17 @@ This enables dead-code elimination in production builds — all `if (!IS_FREEBUF
 
 ## 2. Branding Changes
 
-| Area | Codebuff | Freebuff |
-|---|---|---|
-| Terminal title prefix | `Codebuff: ` | `Freebuff: ` |
-| CLI commander name | `codebuff` | `freebuff` |
-| npm package name | `codebuff` | `freebuff` |
-| Binary name | `codebuff` | `freebuff` |
-| App header text | "Codebuff will run commands on your behalf to help you build." | "Freebuff will run commands on your behalf to help you build." |
-| ASCII logo | `CODEBUFF` block letters | `FREEBUFF` block letters (new logo) |
-| Description | "AI coding agent" | "Free AI coding assistant" |
-| Homepage | codebuff.com | codebuff.com/free (or same) |
-| `WEBSITE_URL` usage | Points to codebuff.com | Same (login, feedback, etc. stay on codebuff.com) |
+| Area                  | Codebuff                                                       | Freebuff                                                       |
+| --------------------- | -------------------------------------------------------------- | -------------------------------------------------------------- |
+| Terminal title prefix | `Codebuff: `                                                   | `Freebuff: `                                                   |
+| CLI commander name    | `codebuff`                                                     | `freebuff`                                                     |
+| npm package name      | `codebuff`                                                     | `freebuff`                                                     |
+| Binary name           | `codebuff`                                                     | `freebuff`                                                     |
+| App header text       | "Codebuff will run commands on your behalf to help you build." | "Freebuff will run commands on your behalf to help you build." |
+| ASCII logo            | `CODEBUFF` block letters                                       | `FREEBUFF` block letters (new logo)                            |
+| Description           | "AI coding agent"                                              | "Free AI coding assistant"                                     |
+| Homepage              | codebuff.com                                                   | codebuff.com/free (or same)                                    |
+| `WEBSITE_URL` usage   | Points to codebuff.com                                         | Same (login, feedback, etc. stay on codebuff.com)              |
 
 ### Files to modify (conditional on `IS_FREEBUFF`)
 
@@ -72,34 +72,34 @@ Freebuff only supports **FREE mode**. All mode-related features are stripped.
 
 ### Commands to REMOVE in Freebuff
 
-| Command | Reason |
-|---|---|
-| `/subscribe` (+ `/strong`, `/sub`, `/buy-credits`) | No subscription model |
-| `/usage` (+ `/credits`) | No credits display |
-| `/ads:enable` | Ads always on, not toggleable |
-| `/ads:disable` | Ads always on, not toggleable |
-| `/connect:claude` (+ `/claude`) | Claude subscription not available |
-| `/refer-friends` (+ `/referral`, `/redeem`) | Referrals earn credits, not applicable |
-| `/mode:*` (all mode commands) | Only FREE mode |
-| `/agent:gpt-5` | Premium agent, not available in free tier |
-| `/review` | Uses thinker-gpt under the hood |
-| `/publish` | Agent publishing not available in free tier |
-| `/image` (+ `/img`, `/attach`) | Image attachments unavailable with free model (GLM 5.1) |
+| Command                                            | Reason                                                    |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| `/subscribe` (+ `/strong`, `/sub`, `/buy-credits`) | No subscription model                                     |
+| `/usage` (+ `/credits`)                            | No credits display                                        |
+| `/ads:enable`                                      | Ads always on, not toggleable                             |
+| `/ads:disable`                                     | Ads always on, not toggleable                             |
+| `/connect:claude` (+ `/claude`)                    | Claude subscription not available                         |
+| `/refer-friends` (+ `/referral`, `/redeem`)        | Referrals earn credits, not applicable                    |
+| `/mode:*` (all mode commands)                      | Only FREE mode                                            |
+| `/agent:gpt-5`                                     | Premium agent, not available in free tier                 |
+| `/review`                                          | Uses thinker-gpt under the hood                           |
+| `/publish`                                         | Agent publishing not available in free tier               |
+| `/image` (+ `/img`, `/attach`)                     | Image attachments unavailable with free model (Kimi K2.6) |
 
 ### Commands to KEEP
 
-| Command | Notes |
-|---|---|
-| `/help` | Modified help content (see §6) |
-| `/new` (+ `/clear`, `/reset`, `/n`, `/c`) | Clear conversation |
-| `/history` (+ `/chats`) | Browse past conversations |
-| `/feedback` (+ `/bug`, `/report`) | Share feedback |
-| `/bash` (+ `/!`) | Bash mode |
-| `/theme:toggle` | Light/dark toggle |
-| `/logout` (+ `/signout`) | Sign out |
-| `/exit` (+ `/quit`, `/q`) | Quit |
-| `/login` (+ `/signin`) | Already-logged-in message |
-| Skill commands (`/skill:*`) | Keep if skills are loaded |
+| Command                                   | Notes                          |
+| ----------------------------------------- | ------------------------------ |
+| `/help`                                   | Modified help content (see §6) |
+| `/new` (+ `/clear`, `/reset`, `/n`, `/c`) | Clear conversation             |
+| `/history` (+ `/chats`)                   | Browse past conversations      |
+| `/feedback` (+ `/bug`, `/report`)         | Share feedback                 |
+| `/bash` (+ `/!`)                          | Bash mode                      |
+| `/theme:toggle`                           | Light/dark toggle              |
+| `/logout` (+ `/signout`)                  | Sign out                       |
+| `/exit` (+ `/quit`, `/q`)                 | Quit                           |
+| `/login` (+ `/signin`)                    | Already-logged-in message      |
+| Skill commands (`/skill:*`)               | Keep if skills are loaded      |
 
 ### Implementation
 
@@ -114,14 +114,14 @@ Freebuff never displays credits, usage, subscription info, or out-of-credits sta
 
 ### Components to suppress (render `null` when `IS_FREEBUFF`)
 
-| Component | File | Behavior |
-|---|---|---|
-| `UsageBanner` | `components/usage-banner.tsx` | Never rendered |
-| `OutOfCreditsBanner` | `components/out-of-credits-banner.tsx` | Never rendered |
-| `SubscriptionLimitBanner` | `components/subscription-limit-banner.tsx` | Never rendered |
-| `BottomStatusLine` | `components/bottom-status-line.tsx` | Never rendered (Claude subscription status) |
-| Credits in `MessageFooter` | `components/message-footer.tsx` | Remove `CreditsOrSubscriptionIndicator` — no credits or "✓ Strong" shown |
-| `ClaudeConnectBanner` | `components/claude-connect-banner.tsx` | Never rendered |
+| Component                  | File                                       | Behavior                                                                 |
+| -------------------------- | ------------------------------------------ | ------------------------------------------------------------------------ |
+| `UsageBanner`              | `components/usage-banner.tsx`              | Never rendered                                                           |
+| `OutOfCreditsBanner`       | `components/out-of-credits-banner.tsx`     | Never rendered                                                           |
+| `SubscriptionLimitBanner`  | `components/subscription-limit-banner.tsx` | Never rendered                                                           |
+| `BottomStatusLine`         | `components/bottom-status-line.tsx`        | Never rendered (Claude subscription status)                              |
+| Credits in `MessageFooter` | `components/message-footer.tsx`            | Remove `CreditsOrSubscriptionIndicator` — no credits or "✓ Strong" shown |
+| `ClaudeConnectBanner`      | `components/claude-connect-banner.tsx`     | Never rendered                                                           |
 
 ### Input modes to disable
 
@@ -258,7 +258,10 @@ const defineFlags = [
   ['process.env.NODE_ENV', '"production"'],
   ['process.env.CODEBUFF_IS_BINARY', '"true"'],
   ['process.env.CODEBUFF_CLI_VERSION', `"${version}"`],
-  ['process.env.CODEBUFF_CLI_TARGET', `"${targetInfo.platform}-${targetInfo.arch}"`],
+  [
+    'process.env.CODEBUFF_CLI_TARGET',
+    `"${targetInfo.platform}-${targetInfo.arch}"`,
+  ],
   // Freebuff mode flag
   ['process.env.FREEBUFF_MODE', `"${process.env.FREEBUFF_MODE ?? 'false'}"`],
   ...nextPublicEnvVars,
@@ -336,11 +339,13 @@ No server-side changes are needed for Freebuff, **except** the release download 
 ## 14. Implementation Phases
 
 ### Phase 1: Core Flag & Branding
+
 1. Add `IS_FREEBUFF` constant
 2. Update `build-binary.ts` to pass through `FREEBUFF_MODE`
 3. Conditional branding (title, logo, app header, CLI name)
 
 ### Phase 2: Feature Stripping
+
 4. Filter slash commands and command registry
 5. Hide agent mode toggle
 6. Suppress credits/subscription UI components
@@ -348,16 +353,19 @@ No server-side changes are needed for Freebuff, **except** the release download 
 8. Simplify help banner
 
 ### Phase 3: Ads & Cleanup
+
 9. Always-on ads behavior
 10. Disable unreachable input modes
 11. Hide `BuildModeButtons` and `ModeDivider` components
 
 ### Phase 4: Build & Release Infrastructure
+
 11. Create `freebuff/cli/release/` package files
 12. Create `freebuff/cli/build.ts` script
 13. Create `.github/workflows/freebuff-release.yml`
 
 ### Phase 5: Testing
+
 14. Add unit tests for IS_FREEBUFF guards
 15. Add integration/E2E tests
 16. Manual QA of built binary

--- a/freebuff/web/src/app/home-client.tsx
+++ b/freebuff/web/src/app/home-client.tsx
@@ -2,11 +2,7 @@
 
 import { AnalyticsEvent } from '@codebuff/common/constants/analytics-events'
 import { AnimatePresence, motion } from 'framer-motion'
-import {
-  Check,
-  ChevronDown,
-  Copy,
-} from 'lucide-react'
+import { Check, ChevronDown, Copy } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import posthog from 'posthog-js'
@@ -20,18 +16,17 @@ import { cn } from '@/lib/utils'
 
 const INSTALL_COMMAND = 'npm install -g freebuff'
 
-const headlineWords = ["The", "free", "coding", "agent"]
+const headlineWords = ['The', 'free', 'coding', 'agent']
 
 const faqs = [
   {
     question: 'How can it be free?',
-    answer:
-      'Freebuff is supported by text ads shown in the CLI.',
+    answer: 'Freebuff is supported by text ads shown in the CLI.',
   },
   {
     question: 'What models do you use?',
     answer:
-      'GLM 5.1 as the main coding agent. Gemini 3.1 Flash Lite for finding files and research.\n\nConnect your ChatGPT subscription to unlock GPT-5.4 for deep thinking.',
+      'Kimi K2.6 as the main coding agent. Gemini 3.1 Flash Lite for finding files and research.\n\nConnect your ChatGPT subscription to unlock GPT-5.4 for deep thinking.',
   },
   {
     question: 'Which countries is Freebuff available in?',
@@ -41,7 +36,7 @@ const faqs = [
   {
     question: 'Are you training on my data?',
     answer:
-      'No. We do not share your data with third parties that would train on it or use it for another purpose.\n\nIn the future, we may use request data to train custom models to improve Freebuff — this will be opt-out, so you\'ll always have control.',
+      "No. We do not share your data with third parties that would train on it or use it for another purpose.\n\nIn the future, we may use request data to train custom models to improve Freebuff — this will be opt-out, so you'll always have control.",
   },
   {
     question: 'What data do you store?',
@@ -50,8 +45,7 @@ const faqs = [
   },
   {
     question: 'What else is cool in Freebuff?',
-    answer:
-      `Freebuff comes with 9 specialized subagents:
+    answer: `Freebuff comes with 9 specialized subagents:
 - file-picker finds relevant files across your codebase
 - code-reviewer gives critical feedback on your changes
 - browser-use lets the AI control a real browser to test your app
@@ -67,7 +61,8 @@ For big tasks, try the commands /interview → /plan → (implement) → /review
 const setupSteps = [
   {
     label: 'Open your terminal',
-    description: 'Use any terminal — within VS Code, plain terminal, PowerShell, etc.',
+    description:
+      'Use any terminal — within VS Code, plain terminal, PowerShell, etc.',
   },
   {
     label: 'Navigate to your project',
@@ -91,9 +86,7 @@ function SetupGuide() {
       <button
         onClick={() => {
           if (!isOpen) {
-            posthog.capture(
-              AnalyticsEvent.FREEBUFF_HOME_INSTALL_GUIDE_EXPANDED,
-            )
+            posthog.capture(AnalyticsEvent.FREEBUFF_HOME_INSTALL_GUIDE_EXPANDED)
           }
           setIsOpen(!isOpen)
         }}
@@ -126,9 +119,13 @@ function SetupGuide() {
                       {i + 1}
                     </span>
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-white/90">{step.label}</p>
+                      <p className="text-sm font-medium text-white/90">
+                        {step.label}
+                      </p>
                       {'description' in step && step.description && (
-                        <p className="text-xs text-zinc-500 mt-0.5">{step.description}</p>
+                        <p className="text-xs text-zinc-500 mt-0.5">
+                          {step.description}
+                        </p>
                       )}
                       {'command' in step && step.command && (
                         <div className="mt-1.5 flex items-center gap-2 bg-zinc-800/60 border border-zinc-700/40 rounded-md px-3 py-1.5 hover:border-acid-matrix/30 transition-colors duration-200">
@@ -156,20 +153,21 @@ function InstallCommand({ className }: { className?: string }) {
   const [copied, setCopied] = useState(false)
   const [copyCount, setCopyCount] = useState(0)
 
-  const particles = useMemo(() =>
-    Array.from({ length: PARTICLE_COUNT }).map((_, i) => ({
-      angle: (i / PARTICLE_COUNT) * 360 + (Math.random() - 0.5) * 25,
-      distance: 35 + Math.random() * 35,
-      size: 3 + Math.random() * 4,
-      durationExtra: Math.random() * 0.3,
-    })),
+  const particles = useMemo(
+    () =>
+      Array.from({ length: PARTICLE_COUNT }).map((_, i) => ({
+        angle: (i / PARTICLE_COUNT) * 360 + (Math.random() - 0.5) * 25,
+        distance: 35 + Math.random() * 35,
+        size: 3 + Math.random() * 4,
+        durationExtra: Math.random() * 0.3,
+      })),
     [copyCount],
   )
 
   const handleCopy = () => {
     navigator.clipboard.writeText(INSTALL_COMMAND)
     setCopied(true)
-    setCopyCount(c => c + 1)
+    setCopyCount((c) => c + 1)
     posthog.capture(AnalyticsEvent.FREEBUFF_HOME_INSTALL_COMMAND_COPIED)
     setTimeout(() => setCopied(false), 1800)
   }
@@ -240,13 +238,20 @@ function InstallCommand({ className }: { className?: string }) {
                   y: Math.sin(rad) * p.distance,
                 }}
                 exit={{ opacity: 0 }}
-                transition={{ duration: 0.5 + p.durationExtra, ease: 'easeOut' }}
+                transition={{
+                  duration: 0.5 + p.durationExtra,
+                  ease: 'easeOut',
+                }}
                 className="absolute right-5 top-1/2 rounded-full pointer-events-none"
                 style={{
                   width: p.size,
                   height: p.size,
                   backgroundColor:
-                    i % 3 === 0 ? '#7CFF3F' : i % 3 === 1 ? '#a8ff7a' : '#ffffff',
+                    i % 3 === 0
+                      ? '#7CFF3F'
+                      : i % 3 === 1
+                        ? '#a8ff7a'
+                        : '#ffffff',
                 }}
               />
             )
@@ -278,10 +283,9 @@ function FAQList() {
             <button
               onClick={() => {
                 if (!isOpen) {
-                  posthog.capture(
-                    AnalyticsEvent.FREEBUFF_HOME_FAQ_OPENED,
-                    { question: faq.question },
-                  )
+                  posthog.capture(AnalyticsEvent.FREEBUFF_HOME_FAQ_OPENED, {
+                    question: faq.question,
+                  })
                 }
                 setOpenIndex(isOpen ? null : i)
               }}
@@ -290,7 +294,9 @@ function FAQList() {
               <span
                 className={cn(
                   'flex-shrink-0 font-mono text-xs transition-colors duration-300',
-                  isOpen ? 'text-acid-matrix' : 'text-zinc-600 group-hover:text-zinc-400',
+                  isOpen
+                    ? 'text-acid-matrix'
+                    : 'text-zinc-600 group-hover:text-zinc-400',
                 )}
               >
                 {String(i + 1).padStart(2, '0')}
@@ -298,7 +304,9 @@ function FAQList() {
               <span
                 className={cn(
                   'font-semibold flex-1 transition-colors duration-300',
-                  isOpen ? 'text-white' : 'text-zinc-300 group-hover:text-white',
+                  isOpen
+                    ? 'text-white'
+                    : 'text-zinc-300 group-hover:text-white',
                 )}
               >
                 {faq.question}
@@ -343,15 +351,22 @@ function FAQList() {
 
 const PHILOSOPHY_WORDS = [
   { word: 'SIMPLE', description: 'No modes. No config. Just works.' },
-  { word: 'FAST', description: '2–5x speed up via fast models and quick context gathering.' },
-  { word: 'LOADED', description: '9 specialized subagents: code review, browser use, deep thinking with your ChatGPT subscription, and more.' },
+  {
+    word: 'FAST',
+    description: '2–5x speed up via fast models and quick context gathering.',
+  },
+  {
+    word: 'LOADED',
+    description:
+      '9 specialized subagents: code review, browser use, deep thinking with your ChatGPT subscription, and more.',
+  },
 ]
 
 function PhilosophySection() {
   const [litWords, setLitWords] = useState<Set<number>>(new Set())
 
   const lightUp = (i: number) => {
-    setLitWords(prev => {
+    setLitWords((prev) => {
       const next = new Set(prev)
       next.add(i)
       return next
@@ -359,7 +374,7 @@ function PhilosophySection() {
   }
 
   const dimDown = (i: number) => {
-    setLitWords(prev => {
+    setLitWords((prev) => {
       const next = new Set(prev)
       next.delete(i)
       return next
@@ -480,7 +495,11 @@ export default function HomeClient() {
                 <motion.span
                   key={i}
                   variants={wordVariant}
-                  className={word === 'free' ? 'inline-block mr-[0.3em] text-acid-matrix neon-text animate-glow-pulse cursor-default hover-glow-flare' : 'inline-block mr-[0.3em] text-white'}
+                  className={
+                    word === 'free'
+                      ? 'inline-block mr-[0.3em] text-acid-matrix neon-text animate-glow-pulse cursor-default hover-glow-flare'
+                      : 'inline-block mr-[0.3em] text-white'
+                  }
                 >
                   {word}
                 </motion.span>
@@ -535,9 +554,7 @@ export default function HomeClient() {
                 transition={{ duration: 0.6 }}
                 className="text-center lg:text-left mb-12"
               >
-                <h2 className="text-3xl md:text-4xl font-bold mb-4">
-                  FAQ
-                </h2>
+                <h2 className="text-3xl md:text-4xl font-bold mb-4">FAQ</h2>
               </motion.div>
 
               <FAQList />

--- a/packages/internal/src/db/schema.ts
+++ b/packages/internal/src/db/schema.ts
@@ -91,7 +91,9 @@ export const user = pgTable('user', {
   auto_topup_threshold: integer('auto_topup_threshold'),
   auto_topup_amount: integer('auto_topup_amount'),
   banned: boolean('banned').notNull().default(false),
-  fallback_to_a_la_carte: boolean('fallback_to_a_la_carte').notNull().default(false),
+  fallback_to_a_la_carte: boolean('fallback_to_a_la_carte')
+    .notNull()
+    .default(false),
 })
 
 export const account = pgTable(
@@ -886,7 +888,11 @@ export const freeSession = pgTable(
   },
   (table) => [
     // Per-model dequeue: WHERE status='queued' AND model=$1 ORDER BY queued_at
-    index('idx_free_session_queue').on(table.status, table.model, table.queued_at),
+    index('idx_free_session_queue').on(
+      table.status,
+      table.model,
+      table.queued_at,
+    ),
     // Expiry sweep: SELECT ... WHERE status='active' AND expires_at < now()
     index('idx_free_session_expiry').on(table.expires_at),
   ],
@@ -894,7 +900,7 @@ export const freeSession = pgTable(
 
 /**
  * Audit log of every admission — one row per queued→active transition. Used
- * to rate-limit heavy users (e.g. no more than 5 GLM sessions per 12h).
+ * to rate-limit heavy users (e.g. no more than 5 Kimi sessions per 12h).
  *
  * Separate from `free_session` because that table is one-row-per-user (state,
  * not history); the UPSERT path there would otherwise destroy prior admissions.

--- a/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
+++ b/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
@@ -83,6 +83,9 @@ describe('/api/v1/chat/completions POST endpoint', () => {
     'cf-ipcountry': 'US',
     'cf-connecting-ip': '203.0.113.10',
   })
+  // Some provider-path tests can cross Bun's 5s default on loaded CI runners
+  // when the mocked network path waits behind unrelated DB reconnect timers.
+  const FETCH_PATH_TEST_TIMEOUT_MS = 15000
 
   beforeEach(() => {
     resetFreeModeRateLimits()
@@ -672,143 +675,153 @@ describe('/api/v1/chat/completions POST endpoint', () => {
       expect(body.countryBlockReason).toBe('anonymized_or_unknown_country')
     })
 
-    it('lets freebuff use Kimi K2.6 through Fireworks availability rules', async () => {
-      const fetchedBodies: Record<string, unknown>[] = []
-      const fetchViaFireworks = mock(
-        async (_url: string | URL | Request, init?: RequestInit) => {
-          fetchedBodies.push(JSON.parse(init?.body as string))
-          return new Response(
-            JSON.stringify({
-              id: 'test-id',
-              model: 'accounts/fireworks/models/kimi-k2p6',
-              choices: [{ message: { content: 'test response' } }],
-              usage: {
-                prompt_tokens: 10,
-                completion_tokens: 20,
-                total_tokens: 30,
+    it(
+      'lets freebuff use Kimi K2.6 through Fireworks availability rules',
+      async () => {
+        const fetchedBodies: Record<string, unknown>[] = []
+        const fetchViaFireworks = mock(
+          async (_url: string | URL | Request, init?: RequestInit) => {
+            fetchedBodies.push(JSON.parse(init?.body as string))
+            return new Response(
+              JSON.stringify({
+                id: 'test-id',
+                model: 'accounts/fireworks/models/kimi-k2p6',
+                choices: [{ message: { content: 'test response' } }],
+                usage: {
+                  prompt_tokens: 10,
+                  completion_tokens: 20,
+                  total_tokens: 30,
+                },
+              }),
+              {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            )
+          },
+        ) as unknown as typeof globalThis.fetch
+
+        const req = new NextRequest(
+          'http://localhost:3000/api/v1/chat/completions',
+          {
+            method: 'POST',
+            headers: allowedFreeModeHeaders('test-api-key-new-free'),
+            body: JSON.stringify({
+              model: 'moonshotai/kimi-k2.6',
+              stream: false,
+              codebuff_metadata: {
+                run_id: 'run-free',
+                client_id: 'test-client-id-123',
+                cost_mode: 'free',
               },
             }),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            },
-          )
-        },
-      ) as unknown as typeof globalThis.fetch
-
-      const req = new NextRequest(
-        'http://localhost:3000/api/v1/chat/completions',
-        {
-          method: 'POST',
-          headers: allowedFreeModeHeaders('test-api-key-new-free'),
-          body: JSON.stringify({
-            model: 'moonshotai/kimi-k2.6',
-            stream: false,
-            codebuff_metadata: {
-              run_id: 'run-free',
-              client_id: 'test-client-id-123',
-              cost_mode: 'free',
-            },
-          }),
-        },
-      )
-
-      const response = await postChatCompletions({
-        req,
-        getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
-        logger: mockLogger,
-        trackEvent: mockTrackEvent,
-        getUserUsageData: mockGetUserUsageData,
-        getAgentRunFromId: mockGetAgentRunFromId,
-        fetch: fetchViaFireworks,
-        insertMessageBigquery: mockInsertMessageBigquery,
-        loggerWithContext: mockLoggerWithContext,
-        checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
-      })
-
-      const body = await response.json()
-      if (isFreebuffDeploymentHours()) {
-        expect(response.status).toBe(200)
-        expect(fetchedBodies).toHaveLength(1)
-        expect(fetchedBodies[0].model).toBe(
-          'accounts/fireworks/models/kimi-k2p6',
+          },
         )
-        expect(body.model).toBe('moonshotai/kimi-k2.6')
-        expect(body.provider).toBe('Fireworks')
-      } else {
-        expect(response.status).toBe(503)
-        expect(fetchedBodies).toHaveLength(0)
-        expect(body.error.code).toBe('DEPLOYMENT_OUTSIDE_HOURS')
-      }
-    })
 
-    it('lets old freebuff clients keep using GLM 5.1 through Fireworks availability rules', async () => {
-      const fetchedBodies: Record<string, unknown>[] = []
-      const fetchViaFireworks = mock(
-        async (_url: string | URL | Request, init?: RequestInit) => {
-          fetchedBodies.push(JSON.parse(init?.body as string))
-          return new Response(
-            JSON.stringify({
-              id: 'test-id',
-              model: 'accounts/fireworks/models/glm-5p1',
-              choices: [{ message: { content: 'test response' } }],
-              usage: {
-                prompt_tokens: 10,
-                completion_tokens: 20,
-                total_tokens: 30,
+        const response = await postChatCompletions({
+          req,
+          getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
+          logger: mockLogger,
+          trackEvent: mockTrackEvent,
+          getUserUsageData: mockGetUserUsageData,
+          getAgentRunFromId: mockGetAgentRunFromId,
+          fetch: fetchViaFireworks,
+          insertMessageBigquery: mockInsertMessageBigquery,
+          loggerWithContext: mockLoggerWithContext,
+          checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
+        })
+
+        const body = await response.json()
+        if (isFreebuffDeploymentHours()) {
+          expect(response.status).toBe(200)
+          expect(fetchedBodies).toHaveLength(1)
+          expect(fetchedBodies[0].model).toBe(
+            'accounts/fireworks/models/kimi-k2p6',
+          )
+          expect(body.model).toBe('moonshotai/kimi-k2.6')
+          expect(body.provider).toBe('Fireworks')
+        } else {
+          expect(response.status).toBe(503)
+          expect(fetchedBodies).toHaveLength(0)
+          expect(body.error.code).toBe('DEPLOYMENT_OUTSIDE_HOURS')
+        }
+      },
+      FETCH_PATH_TEST_TIMEOUT_MS,
+    )
+
+    it(
+      'lets old freebuff clients keep using GLM 5.1 through Fireworks availability rules',
+      async () => {
+        const fetchedBodies: Record<string, unknown>[] = []
+        const fetchViaFireworks = mock(
+          async (_url: string | URL | Request, init?: RequestInit) => {
+            fetchedBodies.push(JSON.parse(init?.body as string))
+            return new Response(
+              JSON.stringify({
+                id: 'test-id',
+                model: 'accounts/fireworks/models/glm-5p1',
+                choices: [{ message: { content: 'test response' } }],
+                usage: {
+                  prompt_tokens: 10,
+                  completion_tokens: 20,
+                  total_tokens: 30,
+                },
+              }),
+              {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            )
+          },
+        ) as unknown as typeof globalThis.fetch
+
+        const req = new NextRequest(
+          'http://localhost:3000/api/v1/chat/completions',
+          {
+            method: 'POST',
+            headers: allowedFreeModeHeaders('test-api-key-new-free'),
+            body: JSON.stringify({
+              model: FREEBUFF_GLM_MODEL_ID,
+              stream: false,
+              codebuff_metadata: {
+                run_id: 'run-free',
+                client_id: 'test-client-id-123',
+                cost_mode: 'free',
               },
             }),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            },
+          },
+        )
+
+        const response = await postChatCompletions({
+          req,
+          getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
+          logger: mockLogger,
+          trackEvent: mockTrackEvent,
+          getUserUsageData: mockGetUserUsageData,
+          getAgentRunFromId: mockGetAgentRunFromId,
+          fetch: fetchViaFireworks,
+          insertMessageBigquery: mockInsertMessageBigquery,
+          loggerWithContext: mockLoggerWithContext,
+          checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
+        })
+
+        const body = await response.json()
+        if (isFreebuffDeploymentHours()) {
+          expect(response.status).toBe(200)
+          expect(fetchedBodies).toHaveLength(1)
+          expect(fetchedBodies[0].model).toBe(
+            'accounts/fireworks/models/glm-5p1',
           )
-        },
-      ) as unknown as typeof globalThis.fetch
-
-      const req = new NextRequest(
-        'http://localhost:3000/api/v1/chat/completions',
-        {
-          method: 'POST',
-          headers: allowedFreeModeHeaders('test-api-key-new-free'),
-          body: JSON.stringify({
-            model: FREEBUFF_GLM_MODEL_ID,
-            stream: false,
-            codebuff_metadata: {
-              run_id: 'run-free',
-              client_id: 'test-client-id-123',
-              cost_mode: 'free',
-            },
-          }),
-        },
-      )
-
-      const response = await postChatCompletions({
-        req,
-        getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
-        logger: mockLogger,
-        trackEvent: mockTrackEvent,
-        getUserUsageData: mockGetUserUsageData,
-        getAgentRunFromId: mockGetAgentRunFromId,
-        fetch: fetchViaFireworks,
-        insertMessageBigquery: mockInsertMessageBigquery,
-        loggerWithContext: mockLoggerWithContext,
-        checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
-      })
-
-      const body = await response.json()
-      if (isFreebuffDeploymentHours()) {
-        expect(response.status).toBe(200)
-        expect(fetchedBodies).toHaveLength(1)
-        expect(fetchedBodies[0].model).toBe('accounts/fireworks/models/glm-5p1')
-        expect(body.model).toBe(FREEBUFF_GLM_MODEL_ID)
-        expect(body.provider).toBe('Fireworks')
-      } else {
-        expect(response.status).toBe(503)
-        expect(fetchedBodies).toHaveLength(0)
-        expect(body.error.code).toBe('DEPLOYMENT_OUTSIDE_HOURS')
-      }
-    })
+          expect(body.model).toBe(FREEBUFF_GLM_MODEL_ID)
+          expect(body.provider).toBe('Fireworks')
+        } else {
+          expect(response.status).toBe(503)
+          expect(fetchedBodies).toHaveLength(0)
+          expect(body.error.code).toBe('DEPLOYMENT_OUTSIDE_HOURS')
+        }
+      },
+      FETCH_PATH_TEST_TIMEOUT_MS,
+    )
 
     it('lets freebuff use Gemini 3.1 Pro through the free-mode allowlist', async () => {
       const req = new NextRequest(
@@ -911,39 +924,43 @@ describe('/api/v1/chat/completions POST endpoint', () => {
       expect(checkFreeModeRateLimit('user-new-free-gemini').limited).toBe(true)
     })
 
-    it('skips credit check when in FREE mode even with 0 credits', async () => {
-      const req = new NextRequest(
-        'http://localhost:3000/api/v1/chat/completions',
-        {
-          method: 'POST',
-          headers: allowedFreeModeHeaders('test-api-key-no-credits'),
-          body: JSON.stringify({
-            model: 'minimax/minimax-m2.7',
-            stream: false,
-            codebuff_metadata: {
-              run_id: 'run-free',
-              client_id: 'test-client-id-123',
-              cost_mode: 'free',
-            },
-          }),
-        },
-      )
+    it(
+      'skips credit check when in FREE mode even with 0 credits',
+      async () => {
+        const req = new NextRequest(
+          'http://localhost:3000/api/v1/chat/completions',
+          {
+            method: 'POST',
+            headers: allowedFreeModeHeaders('test-api-key-no-credits'),
+            body: JSON.stringify({
+              model: 'minimax/minimax-m2.7',
+              stream: false,
+              codebuff_metadata: {
+                run_id: 'run-free',
+                client_id: 'test-client-id-123',
+                cost_mode: 'free',
+              },
+            }),
+          },
+        )
 
-      const response = await postChatCompletions({
-        req,
-        getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
-        logger: mockLogger,
-        trackEvent: mockTrackEvent,
-        getUserUsageData: mockGetUserUsageData,
-        getAgentRunFromId: mockGetAgentRunFromId,
-        fetch: mockFetch,
-        insertMessageBigquery: mockInsertMessageBigquery,
-        loggerWithContext: mockLoggerWithContext,
-        checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
-      })
+        const response = await postChatCompletions({
+          req,
+          getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
+          logger: mockLogger,
+          trackEvent: mockTrackEvent,
+          getUserUsageData: mockGetUserUsageData,
+          getAgentRunFromId: mockGetAgentRunFromId,
+          fetch: mockFetch,
+          insertMessageBigquery: mockInsertMessageBigquery,
+          loggerWithContext: mockLoggerWithContext,
+          checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
+        })
 
-      expect(response.status).toBe(200)
-    })
+        expect(response.status).toBe(200)
+      },
+      FETCH_PATH_TEST_TIMEOUT_MS,
+    )
 
     it('rejects free-mode requests using a non-allowlisted model (e.g. Opus)', async () => {
       const req = new NextRequest(
@@ -1098,43 +1115,49 @@ describe('/api/v1/chat/completions POST endpoint', () => {
       expect(response.headers.get('Connection')).toBe('keep-alive')
     })
 
-    it('returns JSON response for non-streaming requests', async () => {
-      const req = new NextRequest(
-        'http://localhost:3000/api/v1/chat/completions',
-        {
-          method: 'POST',
-          headers: { Authorization: 'Bearer test-api-key-123' },
-          body: JSON.stringify({
-            model: 'test/test-model',
-            stream: false,
-            codebuff_metadata: {
-              run_id: 'run-123',
-              client_id: 'test-client-id-123',
-              client_request_id: 'test-client-session-id-123',
-            },
-          }),
-        },
-      )
+    it(
+      'returns JSON response for non-streaming requests',
+      async () => {
+        const req = new NextRequest(
+          'http://localhost:3000/api/v1/chat/completions',
+          {
+            method: 'POST',
+            headers: { Authorization: 'Bearer test-api-key-123' },
+            body: JSON.stringify({
+              model: 'test/test-model',
+              stream: false,
+              codebuff_metadata: {
+                run_id: 'run-123',
+                client_id: 'test-client-id-123',
+                client_request_id: 'test-client-session-id-123',
+              },
+            }),
+          },
+        )
 
-      const response = await postChatCompletions({
-        req,
-        getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
-        logger: mockLogger,
-        trackEvent: mockTrackEvent,
-        getUserUsageData: mockGetUserUsageData,
-        getAgentRunFromId: mockGetAgentRunFromId,
-        fetch: mockFetch,
-        insertMessageBigquery: mockInsertMessageBigquery,
-        loggerWithContext: mockLoggerWithContext,
-        checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
-      })
+        const response = await postChatCompletions({
+          req,
+          getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
+          logger: mockLogger,
+          trackEvent: mockTrackEvent,
+          getUserUsageData: mockGetUserUsageData,
+          getAgentRunFromId: mockGetAgentRunFromId,
+          fetch: mockFetch,
+          insertMessageBigquery: mockInsertMessageBigquery,
+          loggerWithContext: mockLoggerWithContext,
+          checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
+        })
 
-      expect(response.status).toBe(200)
-      expect(response.headers.get('Content-Type')).toContain('application/json')
-      const body = await response.json()
-      expect(body.id).toBe('test-id')
-      expect(body.choices[0].message.content).toBe('test response')
-    })
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Content-Type')).toContain(
+          'application/json',
+        )
+        const body = await response.json()
+        expect(body.id).toBe('test-id')
+        expect(body.choices[0].message.content).toBe('test response')
+      },
+      FETCH_PATH_TEST_TIMEOUT_MS,
+    )
   })
 
   describe('Subscription limit enforcement', () => {

--- a/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
+++ b/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
@@ -671,7 +671,7 @@ describe('/api/v1/chat/completions POST endpoint', () => {
       expect(body.countryBlockReason).toBe('anonymized_or_unknown_country')
     })
 
-    it('lets freebuff use GLM 5.1 through Fireworks availability rules', async () => {
+    it('lets freebuff use Kimi K2.6 through Fireworks availability rules', async () => {
       const fetchedBodies: Record<string, unknown>[] = []
       const fetchViaFireworks = mock(
         async (_url: string | URL | Request, init?: RequestInit) => {
@@ -679,7 +679,7 @@ describe('/api/v1/chat/completions POST endpoint', () => {
           return new Response(
             JSON.stringify({
               id: 'test-id',
-              model: 'accounts/fireworks/models/glm-5p1',
+              model: 'accounts/fireworks/models/kimi-k2p6',
               choices: [{ message: { content: 'test response' } }],
               usage: {
                 prompt_tokens: 10,
@@ -701,7 +701,7 @@ describe('/api/v1/chat/completions POST endpoint', () => {
           method: 'POST',
           headers: allowedFreeModeHeaders('test-api-key-new-free'),
           body: JSON.stringify({
-            model: 'z-ai/glm-5.1',
+            model: 'moonshotai/kimi-k2.6',
             stream: false,
             codebuff_metadata: {
               run_id: 'run-free',
@@ -729,8 +729,10 @@ describe('/api/v1/chat/completions POST endpoint', () => {
       if (isFreebuffDeploymentHours()) {
         expect(response.status).toBe(200)
         expect(fetchedBodies).toHaveLength(1)
-        expect(fetchedBodies[0].model).toBe('accounts/fireworks/models/glm-5p1')
-        expect(body.model).toBe('z-ai/glm-5.1')
+        expect(fetchedBodies[0].model).toBe(
+          'accounts/fireworks/models/kimi-k2p6',
+        )
+        expect(body.model).toBe('moonshotai/kimi-k2.6')
         expect(body.provider).toBe('Fireworks')
       } else {
         expect(response.status).toBe(503)

--- a/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
+++ b/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 
 import {
   FREEBUFF_GEMINI_PRO_MODEL_ID,
+  FREEBUFF_GLM_MODEL_ID,
   isFreebuffDeploymentHours,
 } from '@codebuff/common/constants/freebuff-models'
 import { formatQuotaResetCountdown, postChatCompletions } from '../_post'
@@ -733,6 +734,74 @@ describe('/api/v1/chat/completions POST endpoint', () => {
           'accounts/fireworks/models/kimi-k2p6',
         )
         expect(body.model).toBe('moonshotai/kimi-k2.6')
+        expect(body.provider).toBe('Fireworks')
+      } else {
+        expect(response.status).toBe(503)
+        expect(fetchedBodies).toHaveLength(0)
+        expect(body.error.code).toBe('DEPLOYMENT_OUTSIDE_HOURS')
+      }
+    })
+
+    it('lets old freebuff clients keep using GLM 5.1 through Fireworks availability rules', async () => {
+      const fetchedBodies: Record<string, unknown>[] = []
+      const fetchViaFireworks = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          fetchedBodies.push(JSON.parse(init?.body as string))
+          return new Response(
+            JSON.stringify({
+              id: 'test-id',
+              model: 'accounts/fireworks/models/glm-5p1',
+              choices: [{ message: { content: 'test response' } }],
+              usage: {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+              },
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          )
+        },
+      ) as unknown as typeof globalThis.fetch
+
+      const req = new NextRequest(
+        'http://localhost:3000/api/v1/chat/completions',
+        {
+          method: 'POST',
+          headers: allowedFreeModeHeaders('test-api-key-new-free'),
+          body: JSON.stringify({
+            model: FREEBUFF_GLM_MODEL_ID,
+            stream: false,
+            codebuff_metadata: {
+              run_id: 'run-free',
+              client_id: 'test-client-id-123',
+              cost_mode: 'free',
+            },
+          }),
+        },
+      )
+
+      const response = await postChatCompletions({
+        req,
+        getUserInfoFromApiKey: mockGetUserInfoFromApiKey,
+        logger: mockLogger,
+        trackEvent: mockTrackEvent,
+        getUserUsageData: mockGetUserUsageData,
+        getAgentRunFromId: mockGetAgentRunFromId,
+        fetch: fetchViaFireworks,
+        insertMessageBigquery: mockInsertMessageBigquery,
+        loggerWithContext: mockLoggerWithContext,
+        checkSessionAdmissible: mockCheckSessionAdmissibleAllow,
+      })
+
+      const body = await response.json()
+      if (isFreebuffDeploymentHours()) {
+        expect(response.status).toBe(200)
+        expect(fetchedBodies).toHaveLength(1)
+        expect(fetchedBodies[0].model).toBe('accounts/fireworks/models/glm-5p1')
+        expect(body.model).toBe(FREEBUFF_GLM_MODEL_ID)
         expect(body.provider).toBe('Fireworks')
       } else {
         expect(response.status).toBe(503)

--- a/web/src/app/api/v1/freebuff/session/__tests__/session.test.ts
+++ b/web/src/app/api/v1/freebuff/session/__tests__/session.test.ts
@@ -281,10 +281,10 @@ describe('POST /api/v1/freebuff/session', () => {
     expect(body.status).toBe('queued')
   })
 
-  test('returns model_unavailable for GLM outside deployment hours', async () => {
+  test('returns model_unavailable for Kimi outside deployment hours', async () => {
     const sessionDeps = makeSessionDeps()
     const resp = await postFreebuffSession(
-      makeReq('ok', { model: 'z-ai/glm-5.1' }),
+      makeReq('ok', { model: 'moonshotai/kimi-k2.6' }),
       makeDeps(sessionDeps, 'u1'),
     )
     expect(resp.status).toBe(409)

--- a/web/src/app/docs/[category]/[slug]/page.tsx
+++ b/web/src/app/docs/[category]/[slug]/page.tsx
@@ -33,7 +33,7 @@ const FAQ_ITEMS = [
   {
     question: 'What model does Codebuff use?',
     answer:
-      'Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or GLM 5.1 in Lite mode. Subagents are matched to their tasks: Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research.',
+      'Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or Kimi K2.6 in Lite mode. Subagents are matched to their tasks: Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research.',
   },
   {
     question: 'Can I use my Claude Pro or Max subscription with Codebuff?',

--- a/web/src/content/advanced/how-does-it-work.mdx
+++ b/web/src/content/advanced/how-does-it-work.mdx
@@ -24,8 +24,8 @@ The main agent ("Buffy") runs on Claude Opus 4.7. It reads your prompt, gathers 
 - [**Code Searcher**](/publishers/codebuff/agents/code-searcher) - grep-style pattern matching
 - [**Researcher**](/publishers/codebuff/agents/researcher) (Gemini 3.1 Flash Lite) - web and docs lookup
 - [**Thinker**](/publishers/codebuff/agents/thinker) (Claude Opus 4.7, GPT-5.4) - works through hard problems
-- [**Editor**](/publishers/codebuff/agents/editor) (Claude Opus 4.7, GPT-5.1, GLM 5.1) - writes and modifies code
-- [**Reviewer**](/publishers/codebuff/agents/reviewer) (Claude Opus 4.7, GLM 5.1 in Lite mode) - catches bugs and style issues
+- [**Editor**](/publishers/codebuff/agents/editor) (Claude Opus 4.7, GPT-5.1, Kimi K2.6) - writes and modifies code
+- [**Reviewer**](/publishers/codebuff/agents/reviewer) (Claude Opus 4.7, Kimi K2.6 in Lite mode) - catches bugs and style issues
 - [**Basher**](/publishers/codebuff/agents/basher) (Gemini 3.1 Flash Lite) - runs terminal commands
 
 ## Best-of-N Selection (Max Mode)

--- a/web/src/content/advanced/what-models.mdx
+++ b/web/src/content/advanced/what-models.mdx
@@ -14,12 +14,8 @@ Codebuff uses different models for different tasks. The orchestrator coordinates
 The main agent ("Buffy") coordinates everything:
 
 <MarkdownTable>
-  | Mode | Model |
-  |------|-------|
-  | Default | Opus 4.7 |
-  | Plan | Opus 4.7 |
-  | Max | Opus 4.7 |
-  | Lite | GLM 5.1 |
+  | Mode | Model | |------|-------| | Default | Opus 4.7 | | Plan | Opus 4.7 | |
+  Max | Opus 4.7 | | Lite | Kimi K2.6 |
 </MarkdownTable>
 
 ## Subagents
@@ -27,14 +23,11 @@ The main agent ("Buffy") coordinates everything:
 The orchestrator spawns these for specific jobs:
 
 <MarkdownTable>
-  | Task | Models |
-  |------|--------|
-  | Code editing | Claude Opus 4.7, GLM 5.1 |
-  | Thinking/reasoning | Claude Opus 4.7, GPT-5.4 |
-  | Code review | Claude Opus 4.7, GPT-5.4 |
-  | File discovery | Gemini 3.1 Flash Lite, Gemini 2.5 Flash Lite |
-  | Terminal commands | Gemini 3.1 Flash Lite |
-  | Web/docs research | Gemini 3.1 Flash Lite |
+  | Task | Models | |------|--------| | Code editing | Claude Opus 4.7, Kimi
+  K2.6 | | Thinking/reasoning | Claude Opus 4.7, GPT-5.4 | | Code review |
+  Claude Opus 4.7, GPT-5.4 | | File discovery | Gemini 3.1 Flash Lite, Gemini
+  2.5 Flash Lite | | Terminal commands | Gemini 3.1 Flash Lite | | Web/docs
+  research | Gemini 3.1 Flash Lite |
 </MarkdownTable>
 
-Max mode runs multiple implementations in parallel and picks the best one. Default mode runs a single implementation pass. Lite mode uses GLM 5.1 and includes code review support.
+Max mode runs multiple implementations in parallel and picks the best one. Default mode runs a single implementation pass. Lite mode uses Kimi K2.6 and includes code review support.

--- a/web/src/content/help/faq.mdx
+++ b/web/src/content/help/faq.mdx
@@ -13,7 +13,7 @@ Software development: Writing features, tests, and scripts across common languag
 
 ## What model does Codebuff use?
 
-Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or GLM 5.1 in Lite mode. Subagents are matched to their tasks: Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research. See [What models do you use?](/docs/advanced/what-models) for the full breakdown.
+Multiple. The orchestrator uses Claude Opus 4.7 in Default and Max modes, or Kimi K2.6 in Lite mode. Subagents are matched to their tasks: Claude Opus 4.7 and GPT-5.4 for deep reasoning and code review, and Gemini 3.1 Flash Lite for terminal commands, file discovery, and web/docs research. See [What models do you use?](/docs/advanced/what-models) for the full breakdown.
 
 ## Can I use my Claude Pro or Max subscription with Codebuff?
 

--- a/web/src/content/tips/modes.mdx
+++ b/web/src/content/tips/modes.mdx
@@ -10,12 +10,10 @@ order: 2
 Codebuff has four modes. Switch during a session with `Shift+Tab` or `/mode:` commands.
 
 <MarkdownTable>
-  | Mode | Model | Editor Agent | Code Review |
-  | --- | --- | --- | --- | --- |
-  | Default | Claude Opus 4.7 | editor | Yes |
-  | Max | Claude Opus 4.7 | editor-multi-prompt | Yes |
-  | Plan | Claude Opus 4.7 | None | No |
-  | Lite | GLM 5.1 | None | No |
+  | Mode | Model | Editor Agent | Code Review | | --- | --- | --- | --- | --- |
+  | Default | Claude Opus 4.7 | editor | Yes | | Max | Claude Opus 4.7 |
+  editor-multi-prompt | Yes | | Plan | Claude Opus 4.7 | None | No | | Lite |
+  Kimi K2.6 | None | No |
 </MarkdownTable>
 
 ## Default
@@ -60,7 +58,7 @@ Switch to this mode with `/mode:plan`.
 
 ## Lite
 
-GLM 5.1, cheaper and faster.
+Kimi K2.6, cheaper and faster.
 
 An efficient mode for most coding tasks.
 

--- a/web/src/llm-api/__tests__/fireworks-deployment.test.ts
+++ b/web/src/llm-api/__tests__/fireworks-deployment.test.ts
@@ -12,6 +12,7 @@ import {
 import type { Logger } from '@codebuff/common/types/contracts/logger'
 
 const STANDARD_MODEL_ID = 'accounts/fireworks/models/glm-5p1'
+const KIMI_STANDARD_MODEL_ID = 'accounts/fireworks/models/kimi-k2p6'
 const DEPLOYMENT_MODEL_ID = 'accounts/james-65d217/deployments/mjb4i7ea'
 const TEST_DEPLOYMENT_MAP = {
   'z-ai/glm-5.1': DEPLOYMENT_MODEL_ID,
@@ -91,6 +92,14 @@ describe('Fireworks deployment routing', () => {
       model: 'z-ai/glm-5.1',
       messages: [{ role: 'user' as const, content: 'test' }],
     }
+    const kimiBody = {
+      model: 'moonshotai/kimi-k2.6',
+      messages: [{ role: 'user' as const, content: 'test' }],
+    }
+    const kimiLiteBody = {
+      ...kimiBody,
+      codebuff_metadata: { cost_mode: 'lite' },
+    }
     const liteBody = {
       ...minimalBody,
       codebuff_metadata: { cost_mode: 'lite' },
@@ -99,11 +108,13 @@ describe('Fireworks deployment routing', () => {
     it('uses standard API when custom deployment is disabled', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -123,11 +134,13 @@ describe('Fireworks deployment routing', () => {
     it('uses standard API for GLM during hours when no deployment is mapped', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -141,6 +154,57 @@ describe('Fireworks deployment routing', () => {
 
       expect(response.status).toBe(200)
       expect(fetchCalls).toEqual([STANDARD_MODEL_ID])
+    })
+
+    it('uses serverless API for Kimi during hours without a deployment', async () => {
+      const fetchCalls: string[] = []
+
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
+
+      const response = await createFireworksRequestWithFallback({
+        body: kimiBody as never,
+        originalModel: 'moonshotai/kimi-k2.6',
+        fetch: mockFetch,
+        logger,
+        useCustomDeployment: true,
+        deploymentMap: {
+          'z-ai/glm-5.1': DEPLOYMENT_MODEL_ID,
+        },
+        sessionId: 'test-user-id',
+        now: IN_DEPLOYMENT_HOURS,
+      })
+
+      expect(response.status).toBe(200)
+      expect(fetchCalls).toEqual([KIMI_STANDARD_MODEL_ID])
+    })
+
+    it('keeps Kimi unavailable outside hours when no deployment is mapped', async () => {
+      const mockFetch = mock(async () => {
+        throw new Error('should not fetch outside deployment hours')
+      }) as unknown as typeof globalThis.fetch
+
+      const response = await createFireworksRequestWithFallback({
+        body: kimiBody as never,
+        originalModel: 'moonshotai/kimi-k2.6',
+        fetch: mockFetch,
+        logger,
+        useCustomDeployment: true,
+        deploymentMap: {
+          'z-ai/glm-5.1': DEPLOYMENT_MODEL_ID,
+        },
+        sessionId: 'test-user-id',
+        now: BEFORE_DEPLOYMENT_HOURS,
+      })
+
+      expect(response.status).toBe(503)
+      const body = await response.json()
+      expect(body.error.code).toBe('DEPLOYMENT_OUTSIDE_HOURS')
     })
 
     it('keeps GLM unavailable outside hours when no deployment is mapped', async () => {
@@ -166,11 +230,13 @@ describe('Fireworks deployment routing', () => {
     it('tries custom deployment during deployment hours', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -191,20 +257,23 @@ describe('Fireworks deployment routing', () => {
     it('returns deployment 503 on DEPLOYMENT_SCALING_UP without serverless fallback', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(
-          JSON.stringify({
-            error: {
-              message: 'Deployment is currently scaled to zero and is scaling up. Please retry your request in a few minutes.',
-              code: 'DEPLOYMENT_SCALING_UP',
-              type: 'error',
-            },
-          }),
-          { status: 503, statusText: 'Service Unavailable' },
-        )
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(
+            JSON.stringify({
+              error: {
+                message:
+                  'Deployment is currently scaled to zero and is scaling up. Please retry your request in a few minutes.',
+                code: 'DEPLOYMENT_SCALING_UP',
+                type: 'error',
+              },
+            }),
+            { status: 503, statusText: 'Service Unavailable' },
+          )
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -225,20 +294,22 @@ describe('Fireworks deployment routing', () => {
     it('returns non-scaling deployment 503 without serverless fallback', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(
-          JSON.stringify({
-            error: {
-              message: 'Service temporarily unavailable',
-              code: 'SERVICE_UNAVAILABLE',
-              type: 'error',
-            },
-          }),
-          { status: 503, statusText: 'Service Unavailable' },
-        )
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(
+            JSON.stringify({
+              error: {
+                message: 'Service temporarily unavailable',
+                code: 'SERVICE_UNAVAILABLE',
+                type: 'error',
+              },
+            }),
+            { status: 503, statusText: 'Service Unavailable' },
+          )
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -259,14 +330,16 @@ describe('Fireworks deployment routing', () => {
     it('returns 500 Internal Error from deployment without serverless fallback', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(
-          JSON.stringify({ error: 'Internal error' }),
-          { status: 500, statusText: 'Internal Server Error' },
-        )
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ error: 'Internal error' }), {
+            status: 500,
+            statusText: 'Internal Server Error',
+          })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -288,11 +361,13 @@ describe('Fireworks deployment routing', () => {
       markDeploymentScalingUp()
 
       const fetchCalls: string[] = []
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -312,11 +387,13 @@ describe('Fireworks deployment routing', () => {
     it('uses standard API for models without a custom deployment', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: { ...minimalBody, model: 'some-other/model' } as never,
@@ -356,18 +433,20 @@ describe('Fireworks deployment routing', () => {
       expect(body.error.code).toBe('DEPLOYMENT_OUTSIDE_HOURS')
     })
 
-    it('falls back to the standard Fireworks API in lite mode outside deployment hours', async () => {
+    it('falls back to the standard Fireworks API for Kimi lite mode outside deployment hours', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
-        body: liteBody as never,
-        originalModel: 'z-ai/glm-5.1',
+        body: kimiLiteBody as never,
+        originalModel: 'moonshotai/kimi-k2.6',
         fetch: mockFetch,
         logger,
         useCustomDeployment: true,
@@ -377,20 +456,22 @@ describe('Fireworks deployment routing', () => {
       })
 
       expect(response.status).toBe(200)
-      expect(fetchCalls).toEqual([STANDARD_MODEL_ID])
+      expect(fetchCalls).toEqual([KIMI_STANDARD_MODEL_ID])
     })
 
     it('returns non-5xx responses from deployment without fallback (e.g. 429)', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(
-          JSON.stringify({ error: { message: 'Rate limited' } }),
-          { status: 429, statusText: 'Too Many Requests' },
-        )
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(
+            JSON.stringify({ error: { message: 'Rate limited' } }),
+            { status: 429, statusText: 'Too Many Requests' },
+          )
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: minimalBody as never,
@@ -412,11 +493,13 @@ describe('Fireworks deployment routing', () => {
     it('transforms reasoning to reasoning_effort (defaults to medium)', async () => {
       const fetchedBodies: Record<string, unknown>[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchedBodies.push(body)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchedBodies.push(body)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       await createFireworksRequestWithFallback({
         body: {
@@ -439,11 +522,13 @@ describe('Fireworks deployment routing', () => {
     it('uses reasoning.effort value when specified', async () => {
       const fetchedBodies: Record<string, unknown>[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchedBodies.push(body)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchedBodies.push(body)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       await createFireworksRequestWithFallback({
         body: {
@@ -466,11 +551,13 @@ describe('Fireworks deployment routing', () => {
     it('skips reasoning_effort when reasoning.enabled is false', async () => {
       const fetchedBodies: Record<string, unknown>[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchedBodies.push(body)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchedBodies.push(body)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       await createFireworksRequestWithFallback({
         body: {
@@ -493,17 +580,21 @@ describe('Fireworks deployment routing', () => {
     it('preserves reasoning_effort when tools are present (Fireworks supports both)', async () => {
       const fetchedBodies: Record<string, unknown>[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchedBodies.push(body)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchedBodies.push(body)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       await createFireworksRequestWithFallback({
         body: {
           ...minimalBody,
           reasoning: { effort: 'high' },
-          tools: [{ type: 'function', function: { name: 'test', arguments: '{}' } }],
+          tools: [
+            { type: 'function', function: { name: 'test', arguments: '{}' } },
+          ],
         } as never,
         originalModel: 'z-ai/glm-5.1',
         fetch: mockFetch,
@@ -521,11 +612,13 @@ describe('Fireworks deployment routing', () => {
     it('passes through reasoning_effort when set directly without reasoning object', async () => {
       const fetchedBodies: Record<string, unknown>[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchedBodies.push(body)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchedBodies.push(body)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       await createFireworksRequestWithFallback({
         body: {
@@ -547,17 +640,21 @@ describe('Fireworks deployment routing', () => {
     it('preserves directly-set reasoning_effort when tools are present', async () => {
       const fetchedBodies: Record<string, unknown>[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchedBodies.push(body)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchedBodies.push(body)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       await createFireworksRequestWithFallback({
         body: {
           ...minimalBody,
           reasoning_effort: 'low',
-          tools: [{ type: 'function', function: { name: 'test', arguments: '{}' } }],
+          tools: [
+            { type: 'function', function: { name: 'test', arguments: '{}' } },
+          ],
         } as never,
         originalModel: 'z-ai/glm-5.1',
         fetch: mockFetch,
@@ -602,23 +699,26 @@ describe('Fireworks deployment routing', () => {
     it('falls back to the standard Fireworks API in lite mode after deployment scaling 503', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        if (fetchCalls.length === 1) {
-          return new Response(
-            JSON.stringify({
-              error: {
-                message: 'Deployment is currently scaled to zero and is scaling up. Please retry your request in a few minutes.',
-                code: 'DEPLOYMENT_SCALING_UP',
-                type: 'error',
-              },
-            }),
-            { status: 503, statusText: 'Service Unavailable' },
-          )
-        }
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          if (fetchCalls.length === 1) {
+            return new Response(
+              JSON.stringify({
+                error: {
+                  message:
+                    'Deployment is currently scaled to zero and is scaling up. Please retry your request in a few minutes.',
+                  code: 'DEPLOYMENT_SCALING_UP',
+                  type: 'error',
+                },
+              }),
+              { status: 503, statusText: 'Service Unavailable' },
+            )
+          }
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: liteBody as never,
@@ -640,11 +740,13 @@ describe('Fireworks deployment routing', () => {
       markDeploymentScalingUp()
 
       const fetchCalls: string[] = []
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: liteBody as never,
@@ -664,14 +766,16 @@ describe('Fireworks deployment routing', () => {
     it('falls back to the standard Fireworks API in lite mode when the deployment request throws', async () => {
       const fetchCalls: string[] = []
 
-      const mockFetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = JSON.parse(init?.body as string)
-        fetchCalls.push(body.model)
-        if (fetchCalls.length === 1) {
-          throw new Error('socket hang up')
-        }
-        return new Response(JSON.stringify({ ok: true }), { status: 200 })
-      }) as unknown as typeof globalThis.fetch
+      const mockFetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = JSON.parse(init?.body as string)
+          fetchCalls.push(body.model)
+          if (fetchCalls.length === 1) {
+            throw new Error('socket hang up')
+          }
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        },
+      ) as unknown as typeof globalThis.fetch
 
       const response = await createFireworksRequestWithFallback({
         body: liteBody as never,

--- a/web/src/llm-api/canopywave.ts
+++ b/web/src/llm-api/canopywave.ts
@@ -34,7 +34,8 @@ interface CanopyWavePricing {
   outputCostPerToken: number
 }
 
-/** Single source of truth: CanopyWave model metadata and per-model pricing. */
+/** Single source of truth for CanopyWave model metadata and pricing.
+ *  Kept as one map so adding a model can't drift between routing and billing. */
 const CANOPYWAVE_MODELS: Record<
   string,
   { canopywaveId: string; pricing: CanopyWavePricing }
@@ -52,7 +53,7 @@ const CANOPYWAVE_MODELS: Record<
     pricing: {
       inputCostPerToken: 0.95 / 1_000_000,
       cachedInputCostPerToken: 0.16 / 1_000_000,
-      outputCostPerToken: 4.0 / 1_000_000,
+      outputCostPerToken: 4.00 / 1_000_000,
     },
   },
 }
@@ -75,12 +76,7 @@ function getCanopyWavePricing(model: string): CanopyWavePricing {
   return entry.pricing
 }
 
-type StreamState = {
-  responseText: string
-  reasoningText: string
-  ttftMs: number | null
-  billedAlready: boolean
-}
+type StreamState = { responseText: string; reasoningText: string; ttftMs: number | null; billedAlready: boolean }
 
 type LineResult = {
   state: StreamState
@@ -129,39 +125,15 @@ function createCanopyWaveRequest(params: {
   })
 }
 
-function extractUsageAndCost(
-  usage: Record<string, unknown> | undefined | null,
-  model: string,
-): UsageData {
-  if (!usage)
-    return {
-      inputTokens: 0,
-      outputTokens: 0,
-      cacheReadInputTokens: 0,
-      reasoningTokens: 0,
-      cost: 0,
-    }
-  const promptDetails = usage.prompt_tokens_details as
-    | Record<string, unknown>
-    | undefined
-    | null
-  const completionDetails = usage.completion_tokens_details as
-    | Record<string, unknown>
-    | undefined
-    | null
+function extractUsageAndCost(usage: Record<string, unknown> | undefined | null, model: string): UsageData {
+  if (!usage) return { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, reasoningTokens: 0, cost: 0 }
+  const promptDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined | null
+  const completionDetails = usage.completion_tokens_details as Record<string, unknown> | undefined | null
 
-  const inputTokens =
-    typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0
-  const outputTokens =
-    typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0
-  const cacheReadInputTokens =
-    typeof promptDetails?.cached_tokens === 'number'
-      ? promptDetails.cached_tokens
-      : 0
-  const reasoningTokens =
-    typeof completionDetails?.reasoning_tokens === 'number'
-      ? completionDetails.reasoning_tokens
-      : 0
+  const inputTokens = typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0
+  const outputTokens = typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0
+  const cacheReadInputTokens = typeof promptDetails?.cached_tokens === 'number' ? promptDetails.cached_tokens : 0
+  const reasoningTokens = typeof completionDetails?.reasoning_tokens === 'number' ? completionDetails.reasoning_tokens : 0
 
   const pricing = getCanopyWavePricing(model)
   const nonCachedInputTokens = Math.max(0, inputTokens - cacheReadInputTokens)
@@ -170,13 +142,7 @@ function extractUsageAndCost(
     cacheReadInputTokens * pricing.cachedInputCostPerToken +
     outputTokens * pricing.outputCostPerToken
 
-  return {
-    inputTokens,
-    outputTokens,
-    cacheReadInputTokens,
-    reasoningTokens,
-    cost,
-  }
+  return { inputTokens, outputTokens, cacheReadInputTokens, reasoningTokens, cost }
 }
 
 export async function handleCanopyWaveNonStream({
@@ -198,10 +164,7 @@ export async function handleCanopyWaveNonStream({
 }) {
   const originalModel = body.model
   const startTime = new Date()
-  const { clientId, clientRequestId, costMode } = extractRequestMetadata({
-    body,
-    logger,
-  })
+  const { clientId, clientRequestId, costMode } = extractRequestMetadata({ body, logger })
 
   const response = await createCanopyWaveRequest({ body, originalModel, fetch })
 
@@ -211,10 +174,7 @@ export async function handleCanopyWaveNonStream({
 
   const data = await response.json()
   const content = data.choices?.[0]?.message?.content ?? ''
-  const reasoningText =
-    data.choices?.[0]?.message?.reasoning_content ??
-    data.choices?.[0]?.message?.reasoning ??
-    ''
+  const reasoningText = data.choices?.[0]?.message?.reasoning_content ?? data.choices?.[0]?.message?.reasoning ?? ''
   const usageData = extractUsageAndCost(data.usage, originalModel)
 
   insertMessageToBigQuery({
@@ -281,10 +241,7 @@ export async function handleCanopyWaveStream({
 }) {
   const originalModel = body.model
   const startTime = new Date()
-  const { clientId, clientRequestId, costMode } = extractRequestMetadata({
-    body,
-    logger,
-  })
+  const { clientId, clientRequestId, costMode } = extractRequestMetadata({ body, logger })
 
   const response = await createCanopyWaveRequest({ body, originalModel, fetch })
 
@@ -298,12 +255,7 @@ export async function handleCanopyWaveStream({
   }
 
   let heartbeatInterval: NodeJS.Timeout
-  let state: StreamState = {
-    responseText: '',
-    reasoningText: '',
-    ttftMs: null,
-    billedAlready: false,
-  }
+  let state: StreamState = { responseText: '', reasoningText: '', ttftMs: null, billedAlready: false }
   let clientDisconnected = false
 
   const stream = new ReadableStream({
@@ -364,13 +316,9 @@ export async function handleCanopyWaveStream({
 
             if (!clientDisconnected) {
               try {
-                controller.enqueue(
-                  new TextEncoder().encode(lineResult.patchedLine),
-                )
+                controller.enqueue(new TextEncoder().encode(lineResult.patchedLine))
               } catch {
-                logger.warn(
-                  'Client disconnected during stream, continuing for billing',
-                )
+                logger.warn('Client disconnected during stream, continuing for billing')
                 clientDisconnected = true
               }
             }
@@ -490,17 +438,13 @@ async function handleLine({
   }
 
   const patchedLine = `data: ${JSON.stringify(obj)}\n`
-  return {
-    state: result.state,
-    billedCredits: result.billedCredits,
-    patchedLine,
-  }
+  return { state: result.state, billedCredits: result.billedCredits, patchedLine }
 }
 
 function isFinalChunk(data: Record<string, unknown>): boolean {
   const choices = data.choices as Array<Record<string, unknown>> | undefined
   if (!choices || choices.length === 0) return true
-  return choices.some((c) => c.finish_reason != null)
+  return choices.some(c => c.finish_reason != null)
 }
 
 async function handleResponse({
@@ -532,24 +476,11 @@ async function handleResponse({
   logger: Logger
   insertMessage: InsertMessageBigqueryFn
 }): Promise<{ state: StreamState; billedCredits?: number }> {
-  state = handleStreamChunk({
-    data,
-    state,
-    startTime,
-    logger,
-    userId,
-    agentId,
-    model: originalModel,
-  })
+  state = handleStreamChunk({ data, state, startTime, logger, userId, agentId, model: originalModel })
 
   // Some providers send cumulative usage on EVERY chunk (not just the final one),
   // so we must only bill once on the final chunk to avoid charging N times.
-  if (
-    'error' in data ||
-    !data.usage ||
-    state.billedAlready ||
-    !isFinalChunk(data)
-  ) {
+  if ('error' in data || !data.usage || state.billedAlready || !isFinalChunk(data)) {
     // Strip usage from non-final chunks and duplicate final chunks
     // so the SDK doesn't see multiple usage objects
     if (data.usage && (!isFinalChunk(data) || state.billedAlready)) {
@@ -558,10 +489,7 @@ async function handleResponse({
     return { state }
   }
 
-  const usageData = extractUsageAndCost(
-    data.usage as Record<string, unknown>,
-    originalModel,
-  )
+  const usageData = extractUsageAndCost(data.usage as Record<string, unknown>, originalModel)
   const messageId = typeof data.id === 'string' ? data.id : 'unknown'
 
   state.billedAlready = true
@@ -649,27 +577,17 @@ function handleStreamChunk({
     if (state.responseText.length >= MAX_BUFFER_SIZE) {
       state.responseText =
         state.responseText.slice(0, MAX_BUFFER_SIZE) + '\n---[TRUNCATED]---'
-      logger.warn(
-        { userId, agentId, model },
-        'Response text buffer truncated at 1MB',
-      )
+      logger.warn({ userId, agentId, model }, 'Response text buffer truncated at 1MB')
     }
   }
 
-  const reasoningDelta =
-    typeof delta?.reasoning_content === 'string'
-      ? delta.reasoning_content
-      : typeof delta?.reasoning === 'string'
-        ? delta.reasoning
-        : ''
+  const reasoningDelta = typeof delta?.reasoning_content === 'string' ? delta.reasoning_content
+    : typeof delta?.reasoning === 'string' ? delta.reasoning
+    : ''
 
   // Track time to first token (TTFT) - set on first meaningful delta (content, reasoning, or tool_calls)
-  const hasToolCallsDelta =
-    delta?.tool_calls != null && (delta.tool_calls as unknown[])?.length > 0
-  if (
-    state.ttftMs === null &&
-    (contentDelta !== '' || reasoningDelta !== '' || hasToolCallsDelta)
-  ) {
+  const hasToolCallsDelta = delta?.tool_calls != null && (delta.tool_calls as unknown[])?.length > 0
+  if (state.ttftMs === null && (contentDelta !== '' || reasoningDelta !== '' || hasToolCallsDelta)) {
     state.ttftMs = Date.now() - startTime.getTime()
   }
 
@@ -678,10 +596,7 @@ function handleStreamChunk({
     if (state.reasoningText.length >= MAX_BUFFER_SIZE) {
       state.reasoningText =
         state.reasoningText.slice(0, MAX_BUFFER_SIZE) + '\n---[TRUNCATED]---'
-      logger.warn(
-        { userId, agentId, model },
-        'Reasoning text buffer truncated at 1MB',
-      )
+      logger.warn({ userId, agentId, model }, 'Reasoning text buffer truncated at 1MB')
     }
   }
 
@@ -715,9 +630,7 @@ export class CanopyWaveError extends Error {
   }
 }
 
-async function parseCanopyWaveError(
-  response: Response,
-): Promise<CanopyWaveError> {
+async function parseCanopyWaveError(response: Response): Promise<CanopyWaveError> {
   const errorText = await response.text()
   let errorBody: CanopyWaveError['errorBody']
   try {

--- a/web/src/llm-api/canopywave.ts
+++ b/web/src/llm-api/canopywave.ts
@@ -34,9 +34,7 @@ interface CanopyWavePricing {
   outputCostPerToken: number
 }
 
-/** Single source of truth: which OpenRouter model IDs we route through
- *  CanopyWave, the corresponding CanopyWave model ID, and per-model pricing.
- *  Kept as one map so adding a model can't drift between routing and billing. */
+/** Single source of truth: CanopyWave model metadata and per-model pricing. */
 const CANOPYWAVE_MODELS: Record<
   string,
   { canopywaveId: string; pricing: CanopyWavePricing }
@@ -49,10 +47,20 @@ const CANOPYWAVE_MODELS: Record<
       outputCostPerToken: 1.08 / 1_000_000,
     },
   },
+  'moonshotai/kimi-k2.6': {
+    canopywaveId: 'moonshotai/kimi-k2.6',
+    pricing: {
+      inputCostPerToken: 0.95 / 1_000_000,
+      cachedInputCostPerToken: 0.16 / 1_000_000,
+      outputCostPerToken: 4.0 / 1_000_000,
+    },
+  },
 }
 
+const CANOPYWAVE_ROUTED_MODELS = new Set<string>(['minimax/minimax-m2.5'])
+
 export function isCanopyWaveModel(model: string): boolean {
-  return model in CANOPYWAVE_MODELS
+  return CANOPYWAVE_ROUTED_MODELS.has(model)
 }
 
 function getCanopyWaveModelId(openrouterModel: string): string {

--- a/web/src/llm-api/canopywave.ts
+++ b/web/src/llm-api/canopywave.ts
@@ -49,14 +49,6 @@ const CANOPYWAVE_MODELS: Record<
       outputCostPerToken: 1.08 / 1_000_000,
     },
   },
-  'moonshotai/kimi-k2.6': {
-    canopywaveId: 'moonshotai/kimi-k2.6',
-    pricing: {
-      inputCostPerToken: 0.95 / 1_000_000,
-      cachedInputCostPerToken: 0.16 / 1_000_000,
-      outputCostPerToken: 4.00 / 1_000_000,
-    },
-  },
 }
 
 export function isCanopyWaveModel(model: string): boolean {
@@ -75,7 +67,12 @@ function getCanopyWavePricing(model: string): CanopyWavePricing {
   return entry.pricing
 }
 
-type StreamState = { responseText: string; reasoningText: string; ttftMs: number | null; billedAlready: boolean }
+type StreamState = {
+  responseText: string
+  reasoningText: string
+  ttftMs: number | null
+  billedAlready: boolean
+}
 
 type LineResult = {
   state: StreamState
@@ -124,15 +121,39 @@ function createCanopyWaveRequest(params: {
   })
 }
 
-function extractUsageAndCost(usage: Record<string, unknown> | undefined | null, model: string): UsageData {
-  if (!usage) return { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, reasoningTokens: 0, cost: 0 }
-  const promptDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined | null
-  const completionDetails = usage.completion_tokens_details as Record<string, unknown> | undefined | null
+function extractUsageAndCost(
+  usage: Record<string, unknown> | undefined | null,
+  model: string,
+): UsageData {
+  if (!usage)
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      reasoningTokens: 0,
+      cost: 0,
+    }
+  const promptDetails = usage.prompt_tokens_details as
+    | Record<string, unknown>
+    | undefined
+    | null
+  const completionDetails = usage.completion_tokens_details as
+    | Record<string, unknown>
+    | undefined
+    | null
 
-  const inputTokens = typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0
-  const outputTokens = typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0
-  const cacheReadInputTokens = typeof promptDetails?.cached_tokens === 'number' ? promptDetails.cached_tokens : 0
-  const reasoningTokens = typeof completionDetails?.reasoning_tokens === 'number' ? completionDetails.reasoning_tokens : 0
+  const inputTokens =
+    typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0
+  const outputTokens =
+    typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0
+  const cacheReadInputTokens =
+    typeof promptDetails?.cached_tokens === 'number'
+      ? promptDetails.cached_tokens
+      : 0
+  const reasoningTokens =
+    typeof completionDetails?.reasoning_tokens === 'number'
+      ? completionDetails.reasoning_tokens
+      : 0
 
   const pricing = getCanopyWavePricing(model)
   const nonCachedInputTokens = Math.max(0, inputTokens - cacheReadInputTokens)
@@ -141,7 +162,13 @@ function extractUsageAndCost(usage: Record<string, unknown> | undefined | null, 
     cacheReadInputTokens * pricing.cachedInputCostPerToken +
     outputTokens * pricing.outputCostPerToken
 
-  return { inputTokens, outputTokens, cacheReadInputTokens, reasoningTokens, cost }
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadInputTokens,
+    reasoningTokens,
+    cost,
+  }
 }
 
 export async function handleCanopyWaveNonStream({
@@ -163,7 +190,10 @@ export async function handleCanopyWaveNonStream({
 }) {
   const originalModel = body.model
   const startTime = new Date()
-  const { clientId, clientRequestId, costMode } = extractRequestMetadata({ body, logger })
+  const { clientId, clientRequestId, costMode } = extractRequestMetadata({
+    body,
+    logger,
+  })
 
   const response = await createCanopyWaveRequest({ body, originalModel, fetch })
 
@@ -173,7 +203,10 @@ export async function handleCanopyWaveNonStream({
 
   const data = await response.json()
   const content = data.choices?.[0]?.message?.content ?? ''
-  const reasoningText = data.choices?.[0]?.message?.reasoning_content ?? data.choices?.[0]?.message?.reasoning ?? ''
+  const reasoningText =
+    data.choices?.[0]?.message?.reasoning_content ??
+    data.choices?.[0]?.message?.reasoning ??
+    ''
   const usageData = extractUsageAndCost(data.usage, originalModel)
 
   insertMessageToBigQuery({
@@ -240,7 +273,10 @@ export async function handleCanopyWaveStream({
 }) {
   const originalModel = body.model
   const startTime = new Date()
-  const { clientId, clientRequestId, costMode } = extractRequestMetadata({ body, logger })
+  const { clientId, clientRequestId, costMode } = extractRequestMetadata({
+    body,
+    logger,
+  })
 
   const response = await createCanopyWaveRequest({ body, originalModel, fetch })
 
@@ -254,7 +290,12 @@ export async function handleCanopyWaveStream({
   }
 
   let heartbeatInterval: NodeJS.Timeout
-  let state: StreamState = { responseText: '', reasoningText: '', ttftMs: null, billedAlready: false }
+  let state: StreamState = {
+    responseText: '',
+    reasoningText: '',
+    ttftMs: null,
+    billedAlready: false,
+  }
   let clientDisconnected = false
 
   const stream = new ReadableStream({
@@ -315,9 +356,13 @@ export async function handleCanopyWaveStream({
 
             if (!clientDisconnected) {
               try {
-                controller.enqueue(new TextEncoder().encode(lineResult.patchedLine))
+                controller.enqueue(
+                  new TextEncoder().encode(lineResult.patchedLine),
+                )
               } catch {
-                logger.warn('Client disconnected during stream, continuing for billing')
+                logger.warn(
+                  'Client disconnected during stream, continuing for billing',
+                )
                 clientDisconnected = true
               }
             }
@@ -437,13 +482,17 @@ async function handleLine({
   }
 
   const patchedLine = `data: ${JSON.stringify(obj)}\n`
-  return { state: result.state, billedCredits: result.billedCredits, patchedLine }
+  return {
+    state: result.state,
+    billedCredits: result.billedCredits,
+    patchedLine,
+  }
 }
 
 function isFinalChunk(data: Record<string, unknown>): boolean {
   const choices = data.choices as Array<Record<string, unknown>> | undefined
   if (!choices || choices.length === 0) return true
-  return choices.some(c => c.finish_reason != null)
+  return choices.some((c) => c.finish_reason != null)
 }
 
 async function handleResponse({
@@ -475,11 +524,24 @@ async function handleResponse({
   logger: Logger
   insertMessage: InsertMessageBigqueryFn
 }): Promise<{ state: StreamState; billedCredits?: number }> {
-  state = handleStreamChunk({ data, state, startTime, logger, userId, agentId, model: originalModel })
+  state = handleStreamChunk({
+    data,
+    state,
+    startTime,
+    logger,
+    userId,
+    agentId,
+    model: originalModel,
+  })
 
   // Some providers send cumulative usage on EVERY chunk (not just the final one),
   // so we must only bill once on the final chunk to avoid charging N times.
-  if ('error' in data || !data.usage || state.billedAlready || !isFinalChunk(data)) {
+  if (
+    'error' in data ||
+    !data.usage ||
+    state.billedAlready ||
+    !isFinalChunk(data)
+  ) {
     // Strip usage from non-final chunks and duplicate final chunks
     // so the SDK doesn't see multiple usage objects
     if (data.usage && (!isFinalChunk(data) || state.billedAlready)) {
@@ -488,7 +550,10 @@ async function handleResponse({
     return { state }
   }
 
-  const usageData = extractUsageAndCost(data.usage as Record<string, unknown>, originalModel)
+  const usageData = extractUsageAndCost(
+    data.usage as Record<string, unknown>,
+    originalModel,
+  )
   const messageId = typeof data.id === 'string' ? data.id : 'unknown'
 
   state.billedAlready = true
@@ -576,17 +641,27 @@ function handleStreamChunk({
     if (state.responseText.length >= MAX_BUFFER_SIZE) {
       state.responseText =
         state.responseText.slice(0, MAX_BUFFER_SIZE) + '\n---[TRUNCATED]---'
-      logger.warn({ userId, agentId, model }, 'Response text buffer truncated at 1MB')
+      logger.warn(
+        { userId, agentId, model },
+        'Response text buffer truncated at 1MB',
+      )
     }
   }
 
-  const reasoningDelta = typeof delta?.reasoning_content === 'string' ? delta.reasoning_content
-    : typeof delta?.reasoning === 'string' ? delta.reasoning
-    : ''
+  const reasoningDelta =
+    typeof delta?.reasoning_content === 'string'
+      ? delta.reasoning_content
+      : typeof delta?.reasoning === 'string'
+        ? delta.reasoning
+        : ''
 
   // Track time to first token (TTFT) - set on first meaningful delta (content, reasoning, or tool_calls)
-  const hasToolCallsDelta = delta?.tool_calls != null && (delta.tool_calls as unknown[])?.length > 0
-  if (state.ttftMs === null && (contentDelta !== '' || reasoningDelta !== '' || hasToolCallsDelta)) {
+  const hasToolCallsDelta =
+    delta?.tool_calls != null && (delta.tool_calls as unknown[])?.length > 0
+  if (
+    state.ttftMs === null &&
+    (contentDelta !== '' || reasoningDelta !== '' || hasToolCallsDelta)
+  ) {
     state.ttftMs = Date.now() - startTime.getTime()
   }
 
@@ -595,7 +670,10 @@ function handleStreamChunk({
     if (state.reasoningText.length >= MAX_BUFFER_SIZE) {
       state.reasoningText =
         state.reasoningText.slice(0, MAX_BUFFER_SIZE) + '\n---[TRUNCATED]---'
-      logger.warn({ userId, agentId, model }, 'Reasoning text buffer truncated at 1MB')
+      logger.warn(
+        { userId, agentId, model },
+        'Reasoning text buffer truncated at 1MB',
+      )
     }
   }
 
@@ -629,7 +707,9 @@ export class CanopyWaveError extends Error {
   }
 }
 
-async function parseCanopyWaveError(response: Response): Promise<CanopyWaveError> {
+async function parseCanopyWaveError(
+  response: Response,
+): Promise<CanopyWaveError> {
   const errorText = await response.text()
   let errorBody: CanopyWaveError['errorBody']
   try {

--- a/web/src/llm-api/fireworks-config.ts
+++ b/web/src/llm-api/fireworks-config.ts
@@ -10,8 +10,8 @@ export const FIREWORKS_ACCOUNT_ID = 'james-65d217'
 
 export const FIREWORKS_DEPLOYMENT_MAP: Record<string, string> = {
   // 'minimax/minimax-m2.5': 'accounts/james-65d217/deployments/lnfid5h9',
-  // Disabled: route GLM 5.1 through the Fireworks serverless API during
+  // Disabled: route Kimi K2.6 through the Fireworks serverless API during
   // availability hours instead of the dedicated deployment.
-  // 'z-ai/glm-5.1': 'accounts/james-65d217/deployments/mjb4i7ea',
+  // 'moonshotai/kimi-k2.6': 'accounts/james-65d217/deployments/mjb4i7ea',
   // 'minimax/minimax-m2.7': 'accounts/james-65d217/deployments/nrdudqxd',
 }

--- a/web/src/llm-api/fireworks.ts
+++ b/web/src/llm-api/fireworks.ts
@@ -2,7 +2,7 @@ import { Agent } from 'undici'
 
 import {
   FREEBUFF_DEPLOYMENT_HOURS_LABEL,
-  FREEBUFF_GLM_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
   isFreebuffDeploymentHours,
 } from '@codebuff/common/constants/freebuff-models'
 import { PROFIT_MARGIN } from '@codebuff/common/constants/limits'
@@ -36,12 +36,14 @@ const fireworksAgent = new Agent({
 const FIREWORKS_MODEL_MAP: Record<string, string> = {
   'minimax/minimax-m2.5': 'accounts/fireworks/models/minimax-m2p5',
   'minimax/minimax-m2.7': 'accounts/fireworks/models/minimax-m2p7',
+  'moonshotai/kimi-k2.6': 'accounts/fireworks/models/kimi-k2p6',
   'z-ai/glm-5.1': 'accounts/fireworks/models/glm-5p1',
 }
 
 /** Models that stay limited to freebuff deployment hours even on serverless. */
 const FIREWORKS_HOURS_GATED_MODELS = new Set<string>([
-  FREEBUFF_GLM_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
+  'z-ai/glm-5.1',
 ])
 
 /** Flag to enable custom Fireworks deployments (set to false to use global API only) */
@@ -79,7 +81,11 @@ function getFireworksModelId(openrouterModel: string): string {
   return FIREWORKS_MODEL_MAP[openrouterModel] ?? openrouterModel
 }
 
-type StreamState = { responseText: string; reasoningText: string; ttftMs: number | null }
+type StreamState = {
+  responseText: string
+  reasoningText: string
+  ttftMs: number | null
+}
 
 type LineResult = {
   state: StreamState
@@ -122,11 +128,20 @@ function createFireworksRequest(params: {
 
   // Add strict: true to tool definitions to prevent hallucinated tool call formats
   if (Array.isArray(fireworksBody.tools)) {
-    fireworksBody.tools = (fireworksBody.tools as Array<Record<string, unknown>>).map((tool) => {
-      if (tool.type === 'function' && typeof tool.function === 'object' && tool.function !== null) {
+    fireworksBody.tools = (
+      fireworksBody.tools as Array<Record<string, unknown>>
+    ).map((tool) => {
+      if (
+        tool.type === 'function' &&
+        typeof tool.function === 'object' &&
+        tool.function !== null
+      ) {
         return {
           ...tool,
-          function: { ...(tool.function as Record<string, unknown>), strict: true },
+          function: {
+            ...(tool.function as Record<string, unknown>),
+            strict: true,
+          },
         }
       }
       return tool
@@ -143,7 +158,7 @@ function createFireworksRequest(params: {
     headers: {
       Authorization: `Bearer ${env.FIREWORKS_API_KEY}`,
       'Content-Type': 'application/json',
-      'x-session-affinity': sessionId
+      'x-session-affinity': sessionId,
     },
     body: JSON.stringify(fireworksBody),
     // @ts-expect-error - dispatcher is a valid undici option not in fetch types
@@ -160,35 +175,67 @@ interface FireworksPricing {
 
 const FIREWORKS_PRICING_MAP: Record<string, FireworksPricing> = {
   'minimax/minimax-m2.5': {
-    inputCostPerToken: 0.30 / 1_000_000,
+    inputCostPerToken: 0.3 / 1_000_000,
     cachedInputCostPerToken: 0.03 / 1_000_000,
-    outputCostPerToken: 1.20 / 1_000_000,
+    outputCostPerToken: 1.2 / 1_000_000,
   },
   'minimax/minimax-m2.7': {
-    inputCostPerToken: 0.30 / 1_000_000,
+    inputCostPerToken: 0.3 / 1_000_000,
     cachedInputCostPerToken: 0.06 / 1_000_000,
-    outputCostPerToken: 1.20 / 1_000_000,
+    outputCostPerToken: 1.2 / 1_000_000,
+  },
+  'moonshotai/kimi-k2.6': {
+    inputCostPerToken: 0.95 / 1_000_000,
+    cachedInputCostPerToken: 0.16 / 1_000_000,
+    outputCostPerToken: 4.0 / 1_000_000,
   },
   'z-ai/glm-5.1': {
-    inputCostPerToken: 1.40 / 1_000_000,
+    inputCostPerToken: 1.4 / 1_000_000,
     cachedInputCostPerToken: 0.26 / 1_000_000,
-    outputCostPerToken: 4.40 / 1_000_000,
+    outputCostPerToken: 4.4 / 1_000_000,
   },
 }
 
 function getFireworksPricing(model: string): FireworksPricing {
-  return FIREWORKS_PRICING_MAP[model] ?? FIREWORKS_PRICING_MAP['z-ai/glm-5.1']
+  return (
+    FIREWORKS_PRICING_MAP[model] ??
+    FIREWORKS_PRICING_MAP[FREEBUFF_KIMI_MODEL_ID]
+  )
 }
 
-function extractUsageAndCost(usage: Record<string, unknown> | undefined | null, model: string): UsageData {
-  if (!usage) return { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, reasoningTokens: 0, cost: 0 }
-  const promptDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined | null
-  const completionDetails = usage.completion_tokens_details as Record<string, unknown> | undefined | null
+function extractUsageAndCost(
+  usage: Record<string, unknown> | undefined | null,
+  model: string,
+): UsageData {
+  if (!usage)
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      reasoningTokens: 0,
+      cost: 0,
+    }
+  const promptDetails = usage.prompt_tokens_details as
+    | Record<string, unknown>
+    | undefined
+    | null
+  const completionDetails = usage.completion_tokens_details as
+    | Record<string, unknown>
+    | undefined
+    | null
 
-  const inputTokens = typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0
-  const outputTokens = typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0
-  const cacheReadInputTokens = typeof promptDetails?.cached_tokens === 'number' ? promptDetails.cached_tokens : 0
-  const reasoningTokens = typeof completionDetails?.reasoning_tokens === 'number' ? completionDetails.reasoning_tokens : 0
+  const inputTokens =
+    typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0
+  const outputTokens =
+    typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0
+  const cacheReadInputTokens =
+    typeof promptDetails?.cached_tokens === 'number'
+      ? promptDetails.cached_tokens
+      : 0
+  const reasoningTokens =
+    typeof completionDetails?.reasoning_tokens === 'number'
+      ? completionDetails.reasoning_tokens
+      : 0
 
   // Fireworks doesn't return cost — compute from token counts and known pricing
   const pricing = getFireworksPricing(model)
@@ -198,7 +245,13 @@ function extractUsageAndCost(usage: Record<string, unknown> | undefined | null, 
     cacheReadInputTokens * pricing.cachedInputCostPerToken +
     outputTokens * pricing.outputCostPerToken
 
-  return { inputTokens, outputTokens, cacheReadInputTokens, reasoningTokens, cost }
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadInputTokens,
+    reasoningTokens,
+    cost,
+  }
 }
 
 export async function handleFireworksNonStream({
@@ -220,9 +273,18 @@ export async function handleFireworksNonStream({
 }) {
   const originalModel = body.model
   const startTime = new Date()
-  const { clientId, clientRequestId, costMode } = extractRequestMetadata({ body, logger })
+  const { clientId, clientRequestId, costMode } = extractRequestMetadata({
+    body,
+    logger,
+  })
 
-  const response = await createFireworksRequestWithFallback({ body, originalModel, fetch, logger, sessionId: userId })
+  const response = await createFireworksRequestWithFallback({
+    body,
+    originalModel,
+    fetch,
+    logger,
+    sessionId: userId,
+  })
 
   if (!response.ok) {
     throw await parseFireworksError(response)
@@ -230,7 +292,10 @@ export async function handleFireworksNonStream({
 
   const data = await response.json()
   const content = data.choices?.[0]?.message?.content ?? ''
-  const reasoningText = data.choices?.[0]?.message?.reasoning_content ?? data.choices?.[0]?.message?.reasoning ?? ''
+  const reasoningText =
+    data.choices?.[0]?.message?.reasoning_content ??
+    data.choices?.[0]?.message?.reasoning ??
+    ''
   const usageData = extractUsageAndCost(data.usage, originalModel)
 
   insertMessageToBigQuery({
@@ -297,9 +362,18 @@ export async function handleFireworksStream({
 }) {
   const originalModel = body.model
   const startTime = new Date()
-  const { clientId, clientRequestId, costMode } = extractRequestMetadata({ body, logger })
+  const { clientId, clientRequestId, costMode } = extractRequestMetadata({
+    body,
+    logger,
+  })
 
-  const response = await createFireworksRequestWithFallback({ body, originalModel, fetch, logger, sessionId: userId })
+  const response = await createFireworksRequestWithFallback({
+    body,
+    originalModel,
+    fetch,
+    logger,
+    sessionId: userId,
+  })
 
   if (!response.ok) {
     throw await parseFireworksError(response)
@@ -372,9 +446,13 @@ export async function handleFireworksStream({
 
             if (!clientDisconnected) {
               try {
-                controller.enqueue(new TextEncoder().encode(lineResult.patchedLine))
+                controller.enqueue(
+                  new TextEncoder().encode(lineResult.patchedLine),
+                )
               } catch {
-                logger.warn('Client disconnected during stream, continuing for billing')
+                logger.warn(
+                  'Client disconnected during stream, continuing for billing',
+                )
                 clientDisconnected = true
               }
             }
@@ -494,7 +572,11 @@ async function handleLine({
   }
 
   const patchedLine = `data: ${JSON.stringify(obj)}\n`
-  return { state: result.state, billedCredits: result.billedCredits, patchedLine }
+  return {
+    state: result.state,
+    billedCredits: result.billedCredits,
+    patchedLine,
+  }
 }
 
 async function handleResponse({
@@ -526,13 +608,24 @@ async function handleResponse({
   logger: Logger
   insertMessage: InsertMessageBigqueryFn
 }): Promise<{ state: StreamState; billedCredits?: number }> {
-  state = handleStreamChunk({ data, state, startTime, logger, userId, agentId, model: originalModel })
+  state = handleStreamChunk({
+    data,
+    state,
+    startTime,
+    logger,
+    userId,
+    agentId,
+    model: originalModel,
+  })
 
   if ('error' in data || !data.usage) {
     return { state }
   }
 
-  const usageData = extractUsageAndCost(data.usage as Record<string, unknown>, originalModel)
+  const usageData = extractUsageAndCost(
+    data.usage as Record<string, unknown>,
+    originalModel,
+  )
   const messageId = typeof data.id === 'string' ? data.id : 'unknown'
 
   insertMessageToBigQuery({
@@ -618,17 +711,27 @@ function handleStreamChunk({
     if (state.responseText.length >= MAX_BUFFER_SIZE) {
       state.responseText =
         state.responseText.slice(0, MAX_BUFFER_SIZE) + '\n---[TRUNCATED]---'
-      logger.warn({ userId, agentId, model }, 'Response text buffer truncated at 1MB')
+      logger.warn(
+        { userId, agentId, model },
+        'Response text buffer truncated at 1MB',
+      )
     }
   }
 
-  const reasoningDelta = typeof delta?.reasoning_content === 'string' ? delta.reasoning_content
-    : typeof delta?.reasoning === 'string' ? delta.reasoning
-      : ''
+  const reasoningDelta =
+    typeof delta?.reasoning_content === 'string'
+      ? delta.reasoning_content
+      : typeof delta?.reasoning === 'string'
+        ? delta.reasoning
+        : ''
 
   // Track time to first token (TTFT) - set on first meaningful delta (content, reasoning, or tool_calls)
-  const hasToolCallsDelta = delta?.tool_calls != null && (delta.tool_calls as unknown[])?.length > 0
-  if (state.ttftMs === null && (contentDelta !== '' || reasoningDelta !== '' || hasToolCallsDelta)) {
+  const hasToolCallsDelta =
+    delta?.tool_calls != null && (delta.tool_calls as unknown[])?.length > 0
+  if (
+    state.ttftMs === null &&
+    (contentDelta !== '' || reasoningDelta !== '' || hasToolCallsDelta)
+  ) {
     state.ttftMs = Date.now() - startTime.getTime()
   }
 
@@ -637,7 +740,10 @@ function handleStreamChunk({
     if (state.reasoningText.length >= MAX_BUFFER_SIZE) {
       state.reasoningText =
         state.reasoningText.slice(0, MAX_BUFFER_SIZE) + '\n---[TRUNCATED]---'
-      logger.warn({ userId, agentId, model }, 'Reasoning text buffer truncated at 1MB')
+      logger.warn(
+        { userId, agentId, model },
+        'Reasoning text buffer truncated at 1MB',
+      )
     }
   }
 
@@ -706,9 +812,15 @@ function parseFireworksErrorFromText(
   return new FireworksError(statusCode, statusText, errorBody)
 }
 
-async function parseFireworksError(response: Response): Promise<FireworksError> {
+async function parseFireworksError(
+  response: Response,
+): Promise<FireworksError> {
   const errorText = await response.text()
-  return parseFireworksErrorFromText(response.status, response.statusText, errorText)
+  return parseFireworksErrorFromText(
+    response.status,
+    response.statusText,
+    errorText,
+  )
 }
 
 /**
@@ -730,12 +842,14 @@ export async function createFireworksRequestWithFallback(params: {
 }): Promise<Response> {
   const { body, originalModel, fetch, logger, sessionId } = params
   const now = params.now ?? new Date()
-  const useCustomDeployment = params.useCustomDeployment ?? FIREWORKS_USE_CUSTOM_DEPLOYMENT
+  const useCustomDeployment =
+    params.useCustomDeployment ?? FIREWORKS_USE_CUSTOM_DEPLOYMENT
   const deploymentMap = params.deploymentMap ?? FIREWORKS_DEPLOYMENT_MAP
   const deploymentModelId = deploymentMap[originalModel]
   const hasDeployment = useCustomDeployment && Boolean(deploymentModelId)
   const isHoursGatedModel = FIREWORKS_HOURS_GATED_MODELS.has(originalModel)
-  const shouldFallbackToStandardApi = body.codebuff_metadata?.cost_mode === 'lite'
+  const shouldFallbackToStandardApi =
+    body.codebuff_metadata?.cost_mode === 'lite'
 
   const createStandardApiRequest = () =>
     createFireworksRequest({ body, originalModel, fetch, sessionId })
@@ -808,7 +922,11 @@ export async function createFireworksRequestWithFallback(params: {
     if (response.status >= 500) {
       const errorText = await response.text()
       logger.info(
-        { model: originalModel, status: response.status, errorText: errorText.slice(0, 200) },
+        {
+          model: originalModel,
+          status: response.status,
+          errorText: errorText.slice(0, 200),
+        },
         'Fireworks custom deployment returned 5xx',
       )
       if (errorText.includes('DEPLOYMENT_SCALING_UP')) {

--- a/web/src/server/free-session/__tests__/admission.test.ts
+++ b/web/src/server/free-session/__tests__/admission.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
+import { FREEBUFF_GLM_MODEL_ID } from '@codebuff/common/constants/freebuff-models'
+
 import { runAdmissionTick } from '../admission'
 
 import type { AdmissionDeps } from '../admission'
@@ -8,7 +10,9 @@ import type { FireworksHealth, FleetHealth } from '../fireworks-health'
 const NOW = new Date('2026-04-17T12:00:00Z')
 const TEST_MODEL = 'test-model'
 
-function makeAdmissionDeps(overrides: Partial<AdmissionDeps> = {}): AdmissionDeps & {
+function makeAdmissionDeps(
+  overrides: Partial<AdmissionDeps> = {},
+): AdmissionDeps & {
   calls: { admit: number }
 } {
   const calls = { admit: 0 }
@@ -37,7 +41,10 @@ function makeAdmissionDeps(overrides: Partial<AdmissionDeps> = {}): AdmissionDep
   return deps
 }
 
-function fleet(health: FireworksHealth, model: string = TEST_MODEL): FleetHealth {
+function fleet(
+  health: FireworksHealth,
+  model: string = TEST_MODEL,
+): FleetHealth {
   return { [model]: health }
 }
 
@@ -100,6 +107,17 @@ describe('runAdmissionTick', () => {
     const deps = makeAdmissionDeps({
       models: ['serverless-model'],
       getFleetHealth: async () => ({}),
+    })
+    const result = await runAdmissionTick(deps)
+    expect(result.admitted).toBe(1)
+    expect(result.skipped).toBeNull()
+  })
+
+  test('legacy GLM 5.1 is admitted during deployment hours', async () => {
+    const deps = makeAdmissionDeps({
+      models: [FREEBUFF_GLM_MODEL_ID],
+      now: () => new Date('2026-04-17T16:00:00Z'),
+      getFleetHealth: async () => ({ [FREEBUFF_GLM_MODEL_ID]: 'healthy' }),
     })
     const result = await runAdmissionTick(deps)
     expect(result.admitted).toBe(1)

--- a/web/src/server/free-session/__tests__/config.test.ts
+++ b/web/src/server/free-session/__tests__/config.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, test } from 'bun:test'
 
-import { FREEBUFF_MODELS } from '@codebuff/common/constants/freebuff-models'
+import {
+  FREEBUFF_MODELS,
+  SUPPORTED_FREEBUFF_MODELS,
+} from '@codebuff/common/constants/freebuff-models'
 
 import { getInstantAdmitCapacity } from '../config'
 
 describe('free session config', () => {
   test('every selectable freebuff model has instant-admit capacity', () => {
     for (const model of FREEBUFF_MODELS) {
+      expect(getInstantAdmitCapacity(model.id)).toBeGreaterThan(0)
+    }
+  })
+
+  test('every supported freebuff model has instant-admit capacity', () => {
+    for (const model of SUPPORTED_FREEBUFF_MODELS) {
       expect(getInstantAdmitCapacity(model.id)).toBeGreaterThan(0)
     }
   })

--- a/web/src/server/free-session/__tests__/public-api.test.ts
+++ b/web/src/server/free-session/__tests__/public-api.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from 'bun:test'
 
 import {
   FREEBUFF_GEMINI_PRO_MODEL_ID,
+  FREEBUFF_GLM_MODEL_ID,
   FREEBUFF_KIMI_MODEL_ID,
 } from '@codebuff/common/constants/freebuff-models'
 
@@ -223,6 +224,54 @@ describe('requestSession', () => {
     expect(deps.rows.size).toBe(0)
   })
 
+  test('legacy GLM 5.1 model is still accepted for old clients during deployment hours', async () => {
+    deps._tick(new Date('2026-04-17T16:00:00Z'))
+    const state = await requestSession({
+      userId: 'u1',
+      model: FREEBUFF_GLM_MODEL_ID,
+      deps,
+    })
+    expect(state.status).toBe('queued')
+    if (state.status !== 'queued') throw new Error('unreachable')
+    expect(deps.rows.get('u1')?.model).toBe(FREEBUFF_GLM_MODEL_ID)
+    expect(state.rateLimit).toEqual({
+      model: FREEBUFF_GLM_MODEL_ID,
+      limit: 5,
+      windowHours: 12,
+      recentCount: 0,
+    })
+  })
+
+  test('legacy GLM 5.1 active session can be reclaimed outside deployment hours', async () => {
+    const admittedAt = new Date(deps._now().getTime() - 10 * 60 * 1000)
+    deps.rows.set('u1', {
+      user_id: 'u1',
+      status: 'active',
+      active_instance_id: 'inst-pre',
+      model: FREEBUFF_GLM_MODEL_ID,
+      queued_at: admittedAt,
+      admitted_at: admittedAt,
+      expires_at: new Date(deps._now().getTime() + SESSION_LEN),
+      created_at: admittedAt,
+      updated_at: admittedAt,
+    })
+
+    const state = await requestSession({
+      userId: 'u1',
+      model: FREEBUFF_GLM_MODEL_ID,
+      deps,
+    })
+    expect(state.status).toBe('active')
+    if (state.status !== 'active') throw new Error('unreachable')
+    expect(state.instanceId).not.toBe('inst-pre')
+    expect(state.rateLimit).toEqual({
+      model: FREEBUFF_GLM_MODEL_ID,
+      limit: 5,
+      windowHours: 12,
+      recentCount: 0,
+    })
+  })
+
   test('queued response includes a per-model depth snapshot for the selector', async () => {
     deps._tick(new Date('2026-04-17T16:00:00Z'))
     // Seed 2 users in MiniMax + 1 in Kimi so the returned map captures both.
@@ -434,6 +483,29 @@ describe('requestSession', () => {
     expect(state.retryAfterMs).toBe(60 * 60 * 1000)
     // Blocked before any row is written — the user doesn't take a queue slot.
     expect(deps.rows.has('u1')).toBe(false)
+  })
+
+  test('rate_limited: legacy GLM 5.1 keeps the deployment-hours quota', async () => {
+    deps._tick(KIMI_OPEN_TIME)
+    const now = deps._now()
+    for (let i = 0; i < KIMI_LIMIT; i++) {
+      deps.admits.push({
+        user_id: 'u1',
+        model: FREEBUFF_GLM_MODEL_ID,
+        admitted_at: new Date(now.getTime() - (i + 1) * 60 * 60 * 1000),
+      })
+    }
+
+    const state = await requestSession({
+      userId: 'u1',
+      model: FREEBUFF_GLM_MODEL_ID,
+      deps,
+    })
+    expect(state.status).toBe('rate_limited')
+    if (state.status !== 'rate_limited') throw new Error('unreachable')
+    expect(state.model).toBe(FREEBUFF_GLM_MODEL_ID)
+    expect(state.limit).toBe(KIMI_LIMIT)
+    expect(state.windowHours).toBe(KIMI_WINDOW_HOURS)
   })
 
   test('rate_limited: admits outside the 12h window do not count', async () => {

--- a/web/src/server/free-session/__tests__/public-api.test.ts
+++ b/web/src/server/free-session/__tests__/public-api.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 
-import { FREEBUFF_GEMINI_PRO_MODEL_ID } from '@codebuff/common/constants/freebuff-models'
+import {
+  FREEBUFF_GEMINI_PRO_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
+} from '@codebuff/common/constants/freebuff-models'
 
 import {
   checkSessionAdmissible,
@@ -194,7 +197,11 @@ describe('requestSession', () => {
   })
 
   test('first call puts user in queue at position 1', async () => {
-    const state = await requestSession({ userId: 'u1', model: DEFAULT_MODEL, deps })
+    const state = await requestSession({
+      userId: 'u1',
+      model: DEFAULT_MODEL,
+      deps,
+    })
     expect(state.status).toBe('queued')
     if (state.status !== 'queued') throw new Error('unreachable')
     expect(state.position).toBe(1)
@@ -205,12 +212,12 @@ describe('requestSession', () => {
   test('deployment-hours-only model is unavailable outside deployment hours', async () => {
     const state = await requestSession({
       userId: 'u1',
-      model: 'z-ai/glm-5.1',
+      model: 'moonshotai/kimi-k2.6',
       deps,
     })
     expect(state).toEqual({
       status: 'model_unavailable',
-      requestedModel: 'z-ai/glm-5.1',
+      requestedModel: 'moonshotai/kimi-k2.6',
       availableHours: '9am ET-5pm PT every day',
     })
     expect(deps.rows.size).toBe(0)
@@ -218,24 +225,28 @@ describe('requestSession', () => {
 
   test('queued response includes a per-model depth snapshot for the selector', async () => {
     deps._tick(new Date('2026-04-17T16:00:00Z'))
-    // Seed 2 users in MiniMax + 1 in GLM so the returned map captures both.
+    // Seed 2 users in MiniMax + 1 in Kimi so the returned map captures both.
     await requestSession({ userId: 'u1', model: DEFAULT_MODEL, deps })
     deps._tick(new Date(deps._now().getTime() + 1000))
     await requestSession({ userId: 'u2', model: DEFAULT_MODEL, deps })
     deps._tick(new Date(deps._now().getTime() + 1000))
-    await requestSession({ userId: 'u3', model: 'z-ai/glm-5.1', deps })
+    await requestSession({ userId: 'u3', model: 'moonshotai/kimi-k2.6', deps })
 
     const state = await getSessionState({ userId: 'u1', deps })
     if (state.status !== 'queued') throw new Error('unreachable')
     expect(state.queueDepthByModel).toEqual({
       [DEFAULT_MODEL]: 2,
-      'z-ai/glm-5.1': 1,
+      'moonshotai/kimi-k2.6': 1,
     })
   })
 
   test('second call from same user rotates instance id, keeps queue position', async () => {
     await requestSession({ userId: 'u1', model: DEFAULT_MODEL, deps })
-    const second = await requestSession({ userId: 'u1', model: DEFAULT_MODEL, deps })
+    const second = await requestSession({
+      userId: 'u1',
+      model: DEFAULT_MODEL,
+      deps,
+    })
     if (second.status !== 'queued') throw new Error('unreachable')
     expect(second.position).toBe(1)
     expect(second.instanceId).toBe('inst-2')
@@ -248,7 +259,8 @@ describe('requestSession', () => {
 
     const s1 = await getSessionState({ userId: 'u1', deps })
     const s2 = await getSessionState({ userId: 'u2', deps })
-    if (s1.status !== 'queued' || s2.status !== 'queued') throw new Error('unreachable')
+    if (s1.status !== 'queued' || s2.status !== 'queued')
+      throw new Error('unreachable')
     expect(s1.position).toBe(1)
     expect(s2.position).toBe(2)
   })
@@ -261,7 +273,11 @@ describe('requestSession', () => {
     row.admitted_at = deps._now()
     row.expires_at = new Date(deps._now().getTime() + SESSION_LEN)
 
-    const second = await requestSession({ userId: 'u1', model: DEFAULT_MODEL, deps })
+    const second = await requestSession({
+      userId: 'u1',
+      model: DEFAULT_MODEL,
+      deps,
+    })
     expect(second.status).toBe('active')
     if (second.status !== 'active') throw new Error('unreachable')
     expect(second.instanceId).not.toBe('inst-1') // rotated
@@ -304,13 +320,16 @@ describe('requestSession', () => {
   })
 
   test('instant-admit: per-model capacities are independent', async () => {
-    // MiniMax saturated at 1 active, GLM still has room.
+    // MiniMax saturated at 1 active, Kimi still has room.
     const admitDeps = makeDeps({
-      getInstantAdmitCapacity: (model) =>
-        model === DEFAULT_MODEL ? 1 : 10,
+      getInstantAdmitCapacity: (model) => (model === DEFAULT_MODEL ? 1 : 10),
     })
     admitDeps._tick(new Date('2026-04-17T16:00:00Z'))
-    await requestSession({ userId: 'u1', model: DEFAULT_MODEL, deps: admitDeps })
+    await requestSession({
+      userId: 'u1',
+      model: DEFAULT_MODEL,
+      deps: admitDeps,
+    })
     const s2 = await requestSession({
       userId: 'u2',
       model: DEFAULT_MODEL,
@@ -318,27 +337,27 @@ describe('requestSession', () => {
     })
     const s3 = await requestSession({
       userId: 'u3',
-      model: 'z-ai/glm-5.1',
+      model: 'moonshotai/kimi-k2.6',
       deps: admitDeps,
     })
     expect(s2.status).toBe('queued')
     expect(s3.status).toBe('active')
   })
 
-  // Per-user rate limit (5 GLM admissions per 12h) — the wire limit is
+  // Per-user rate limit (5 Kimi admissions per 12h) — the wire limit is
   // hard-coded in public-api.ts, so tests seed the fake admit log directly
-  // rather than configuring it. GLM also has deployment-hours gating, so
+  // rather than configuring it. Kimi also has deployment-hours gating, so
   // these tests bump `now` into the open window (12pm ET on a weekday)
   // before issuing the request.
-  const GLM_MODEL = 'z-ai/glm-5.1'
-  const GLM_LIMIT = 5
-  const GLM_WINDOW_HOURS = 12
-  const GLM_OPEN_TIME = new Date('2026-04-17T16:00:00Z')
+  const KIMI_MODEL = FREEBUFF_KIMI_MODEL_ID
+  const KIMI_LIMIT = 5
+  const KIMI_WINDOW_HOURS = 12
+  const KIMI_OPEN_TIME = new Date('2026-04-17T16:00:00Z')
   const GEMINI_LIMIT = 1
   const GEMINI_WINDOW_HOURS = 24
 
   test('rate_limited: Gemini 3.1 Pro allows one admit per 24h', async () => {
-    deps._tick(GLM_OPEN_TIME)
+    deps._tick(KIMI_OPEN_TIME)
     const now = deps._now()
     deps.admits.push({
       user_id: 'u1',
@@ -362,7 +381,7 @@ describe('requestSession', () => {
   })
 
   test('rate_limited: Gemini 3.1 Pro admit outside 24h window does not count', async () => {
-    deps._tick(GLM_OPEN_TIME)
+    deps._tick(KIMI_OPEN_TIME)
     const now = deps._now()
     deps.admits.push({
       user_id: 'u1',
@@ -385,8 +404,8 @@ describe('requestSession', () => {
     })
   })
 
-  test('rate_limited: 5th GLM admit in window blocks the 6th attempt', async () => {
-    deps._tick(GLM_OPEN_TIME)
+  test('rate_limited: 5th Kimi admit in window blocks the 6th attempt', async () => {
+    deps._tick(KIMI_OPEN_TIME)
     // Seed 5 admits inside the 12h window, spaced so we can verify retryAfter
     // points at the oldest one sliding off.
     const now = deps._now()
@@ -395,22 +414,22 @@ describe('requestSession', () => {
     for (const hoursAgo of ages) {
       deps.admits.push({
         user_id: 'u1',
-        model: GLM_MODEL,
+        model: KIMI_MODEL,
         admitted_at: new Date(now.getTime() - hoursAgo * 60 * 60 * 1000),
       })
     }
 
     const state = await requestSession({
       userId: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       deps,
     })
     expect(state.status).toBe('rate_limited')
     if (state.status !== 'rate_limited') throw new Error('unreachable')
-    expect(state.model).toBe(GLM_MODEL)
-    expect(state.limit).toBe(GLM_LIMIT)
-    expect(state.windowHours).toBe(GLM_WINDOW_HOURS)
-    expect(state.recentCount).toBe(GLM_LIMIT)
+    expect(state.model).toBe(KIMI_MODEL)
+    expect(state.limit).toBe(KIMI_LIMIT)
+    expect(state.windowHours).toBe(KIMI_WINDOW_HOURS)
+    expect(state.recentCount).toBe(KIMI_LIMIT)
     // Oldest admit is 11h ago; slot opens when it hits 12h, i.e. in 1h.
     expect(state.retryAfterMs).toBe(60 * 60 * 1000)
     // Blocked before any row is written — the user doesn't take a queue slot.
@@ -418,21 +437,21 @@ describe('requestSession', () => {
   })
 
   test('rate_limited: admits outside the 12h window do not count', async () => {
-    deps._tick(GLM_OPEN_TIME)
+    deps._tick(KIMI_OPEN_TIME)
     // 5 admits, each just over 12h old → all fall off the window.
     const now = deps._now()
     for (let i = 0; i < 5; i++) {
       deps.admits.push({
         user_id: 'u1',
-        model: GLM_MODEL,
+        model: KIMI_MODEL,
         admitted_at: new Date(
-          now.getTime() - (GLM_WINDOW_HOURS * 60 * 60 * 1000 + 60_000 + i),
+          now.getTime() - (KIMI_WINDOW_HOURS * 60 * 60 * 1000 + 60_000 + i),
         ),
       })
     }
     const state = await requestSession({
       userId: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       deps,
     })
     expect(state.status).toBe('queued')
@@ -460,41 +479,41 @@ describe('requestSession', () => {
     expect(state.rateLimit).toBeUndefined()
   })
 
-  test('queued GLM response carries the current admit count', async () => {
-    deps._tick(GLM_OPEN_TIME)
+  test('queued Kimi response carries the current admit count', async () => {
+    deps._tick(KIMI_OPEN_TIME)
     const now = deps._now()
     // 2 admits in the window — under the limit so the user still queues.
     deps.admits.push({
       user_id: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       admitted_at: new Date(now.getTime() - 60 * 60 * 1000),
     })
     deps.admits.push({
       user_id: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       admitted_at: new Date(now.getTime() - 30 * 60 * 1000),
     })
     const state = await requestSession({
       userId: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       deps,
     })
     if (state.status !== 'queued') throw new Error('unreachable')
     expect(state.rateLimit).toEqual({
-      model: GLM_MODEL,
-      limit: GLM_LIMIT,
-      windowHours: GLM_WINDOW_HOURS,
+      model: KIMI_MODEL,
+      limit: KIMI_LIMIT,
+      windowHours: KIMI_WINDOW_HOURS,
       recentCount: 2,
     })
   })
 
-  test('rate_limited: takeover of an active GLM row is allowed even when at cap', async () => {
-    // Reclaim path: user has an active+unexpired GLM session and restarts
+  test('rate_limited: takeover of an active Kimi row is allowed even when at cap', async () => {
+    // Reclaim path: user has an active+unexpired Kimi session and restarts
     // the CLI. POST must rotate their instance id (takeover) and NOT reject
     // with rate_limited — otherwise they'd be stranded with a live session
     // they can't reconnect to. The 5th admission is already in the log, so
     // this also exercises "at the cap" rather than "over the cap".
-    deps._tick(GLM_OPEN_TIME)
+    deps._tick(KIMI_OPEN_TIME)
     const now = deps._now()
     // Seed 5 prior admits (the cap), with the latest one matching the
     // active row we're about to install.
@@ -502,7 +521,7 @@ describe('requestSession', () => {
     for (const hoursAgo of ages) {
       deps.admits.push({
         user_id: 'u1',
-        model: GLM_MODEL,
+        model: KIMI_MODEL,
         admitted_at: new Date(now.getTime() - hoursAgo * 60 * 60 * 1000),
       })
     }
@@ -513,7 +532,7 @@ describe('requestSession', () => {
       user_id: 'u1',
       status: 'active',
       active_instance_id: 'inst-pre',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       queued_at: admittedAt,
       admitted_at: admittedAt,
       expires_at: new Date(admittedAt.getTime() + SESSION_LEN),
@@ -523,27 +542,27 @@ describe('requestSession', () => {
 
     const state = await requestSession({
       userId: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       deps,
     })
     expect(state.status).toBe('active')
     if (state.status !== 'active') throw new Error('unreachable')
     // Instance id rotated; quota snapshot still reflects the full window.
     expect(state.instanceId).not.toBe('inst-pre')
-    expect(state.rateLimit?.recentCount).toBe(GLM_LIMIT)
+    expect(state.rateLimit?.recentCount).toBe(KIMI_LIMIT)
   })
 
-  test('rate_limited: reclaim of a queued GLM row is allowed even when at cap', async () => {
+  test('rate_limited: reclaim of a queued Kimi row is allowed even when at cap', async () => {
     // Same reclaim exception for queued rows: if a user has already queued
     // (say they slipped in just before their 5th admit landed), a subsequent
     // POST from the same CLI must preserve their queue position instead of
     // flipping to rate_limited.
-    deps._tick(GLM_OPEN_TIME)
+    deps._tick(KIMI_OPEN_TIME)
     const now = deps._now()
-    for (let i = 0; i < GLM_LIMIT; i++) {
+    for (let i = 0; i < KIMI_LIMIT; i++) {
       deps.admits.push({
         user_id: 'u1',
-        model: GLM_MODEL,
+        model: KIMI_MODEL,
         admitted_at: new Date(now.getTime() - (i + 1) * 60 * 60 * 1000),
       })
     }
@@ -552,7 +571,7 @@ describe('requestSession', () => {
       user_id: 'u1',
       status: 'queued',
       active_instance_id: 'inst-pre',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       queued_at: queuedAt,
       admitted_at: null,
       expires_at: null,
@@ -562,7 +581,7 @@ describe('requestSession', () => {
 
     const state = await requestSession({
       userId: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       deps,
     })
     expect(state.status).toBe('queued')
@@ -570,20 +589,20 @@ describe('requestSession', () => {
     // Same position (1) since we preserved queued_at and nobody else is
     // ahead; the instance id rotated so any prior CLI is superseded.
     expect(state.instanceId).not.toBe('inst-pre')
-    expect(state.rateLimit?.recentCount).toBe(GLM_LIMIT)
+    expect(state.rateLimit?.recentCount).toBe(KIMI_LIMIT)
   })
 
-  test('rate_limited: expired GLM row is not a reclaim — quota still applies', async () => {
+  test('rate_limited: expired Kimi row is not a reclaim — quota still applies', async () => {
     // The stored row's expires_at is in the past, so it doesn't represent
     // an in-flight session. This POST is effectively a fresh request and
     // must be blocked by the quota.
-    deps._tick(GLM_OPEN_TIME)
+    deps._tick(KIMI_OPEN_TIME)
     const now = deps._now()
     const ages = [11, 4, 3, 2, 1]
     for (const hoursAgo of ages) {
       deps.admits.push({
         user_id: 'u1',
-        model: GLM_MODEL,
+        model: KIMI_MODEL,
         admitted_at: new Date(now.getTime() - hoursAgo * 60 * 60 * 1000),
       })
     }
@@ -592,7 +611,7 @@ describe('requestSession', () => {
       user_id: 'u1',
       status: 'active',
       active_instance_id: 'inst-pre',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       queued_at: admittedAt,
       admitted_at: admittedAt,
       expires_at: new Date(admittedAt.getTime() + SESSION_LEN),
@@ -601,7 +620,7 @@ describe('requestSession', () => {
     })
     const state = await requestSession({
       userId: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       deps,
     })
     expect(state.status).toBe('rate_limited')
@@ -609,18 +628,18 @@ describe('requestSession', () => {
 
   test('instant-admit bumps the quota count for the freshly-written admit row', async () => {
     const admitDeps = makeDeps({ getInstantAdmitCapacity: () => 3 })
-    admitDeps._tick(GLM_OPEN_TIME)
+    admitDeps._tick(KIMI_OPEN_TIME)
     // 1 existing admit in the window; this new call should instant-admit and
     // write a second row, so the response's recentCount reflects 2.
     const now = admitDeps._now()
     admitDeps.admits.push({
       user_id: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       admitted_at: new Date(now.getTime() - 30 * 60 * 1000),
     })
     const state = await requestSession({
       userId: 'u1',
-      model: GLM_MODEL,
+      model: KIMI_MODEL,
       deps: admitDeps,
     })
     if (state.status !== 'active') throw new Error('unreachable')
@@ -688,16 +707,16 @@ describe('getSessionState', () => {
     // Regression: the POST response attached rateLimit, but GET polls did
     // not — so the "Sessions N/M used" line flashed once then disappeared on
     // the next 5s poll. GET must attach the same quota snapshot. Rate
-    // limits only apply to GLM, so this test uses GLM explicitly (inside
+    // limits only apply to Kimi, so this test uses Kimi explicitly (inside
     // deployment hours) rather than the Minimax DEFAULT_MODEL.
     deps._tick(new Date('2026-04-17T16:00:00Z'))
     const now = deps._now()
     deps.admits.push({
       user_id: 'u1',
-      model: 'z-ai/glm-5.1',
+      model: 'moonshotai/kimi-k2.6',
       admitted_at: new Date(now.getTime() - 60 * 60 * 1000),
     })
-    await requestSession({ userId: 'u1', model: 'z-ai/glm-5.1', deps })
+    await requestSession({ userId: 'u1', model: 'moonshotai/kimi-k2.6', deps })
     const row = deps.rows.get('u1')!
     row.status = 'active'
     row.admitted_at = now
@@ -710,7 +729,7 @@ describe('getSessionState', () => {
     })
     if (state.status !== 'active') throw new Error('unreachable')
     expect(state.rateLimit).toEqual({
-      model: 'z-ai/glm-5.1',
+      model: 'moonshotai/kimi-k2.6',
       limit: 5,
       windowHours: 12,
       recentCount: 1,
@@ -890,7 +909,8 @@ describe('checkSessionAdmissible', () => {
       deps,
     })
     expect(result.ok).toBe(true)
-    if (!result.ok || result.reason !== 'draining') throw new Error('unreachable')
+    if (!result.ok || result.reason !== 'draining')
+      throw new Error('unreachable')
     expect(result.gracePeriodRemainingMs).toBe(GRACE_MS - 60_000)
   })
 

--- a/web/src/server/free-session/__tests__/session-view.test.ts
+++ b/web/src/server/free-session/__tests__/session-view.test.ts
@@ -7,7 +7,7 @@ import type { InternalSessionRow } from '../types'
 const WAIT_PER_SPOT_MS = 24_000
 const GRACE_MS = 30 * 60_000
 
-const TEST_MODEL = 'z-ai/glm-5.1'
+const TEST_MODEL = 'moonshotai/kimi-k2.6'
 
 function row(overrides: Partial<InternalSessionRow> = {}): InternalSessionRow {
   const now = new Date('2026-04-17T12:00:00Z')
@@ -81,7 +81,11 @@ describe('toSessionStateResponse', () => {
     const admittedAt = new Date(now.getTime() - 10 * 60_000)
     const expiresAt = new Date(now.getTime() + 50 * 60_000)
     const view = toSessionStateResponse({
-      row: row({ status: 'active', admitted_at: admittedAt, expires_at: expiresAt }),
+      row: row({
+        status: 'active',
+        admitted_at: admittedAt,
+        expires_at: expiresAt,
+      }),
       position: 0,
       ...baseArgs,
       now,
@@ -100,7 +104,11 @@ describe('toSessionStateResponse', () => {
     const admittedAt = new Date(now.getTime() - 65 * 60_000)
     const expiresAt = new Date(now.getTime() - 5 * 60_000) // 5 min past expiry
     const view = toSessionStateResponse({
-      row: row({ status: 'active', admitted_at: admittedAt, expires_at: expiresAt }),
+      row: row({
+        status: 'active',
+        admitted_at: admittedAt,
+        expires_at: expiresAt,
+      }),
       position: 0,
       ...baseArgs,
       now,

--- a/web/src/server/free-session/admission.ts
+++ b/web/src/server/free-session/admission.ts
@@ -1,5 +1,5 @@
 import {
-  FREEBUFF_MODELS,
+  SUPPORTED_FREEBUFF_MODELS,
   isFreebuffModelAvailable,
 } from '@codebuff/common/constants/freebuff-models'
 
@@ -32,7 +32,10 @@ export interface AdmissionDeps {
     sessionLengthMs: number
     now: Date
     health: FireworksHealth
-  }) => Promise<{ admitted: { user_id: string }[]; skipped: FireworksHealth | null }>
+  }) => Promise<{
+    admitted: { user_id: string }[]
+    skipped: FireworksHealth | null
+  }>
   getFleetHealth: () => Promise<FleetHealth>
   /** Plain values, not thunks — these never change at runtime. */
   sessionLengthMs: number
@@ -101,7 +104,7 @@ export async function runAdmissionTick(
     deps.evictBanned(),
   ])
 
-  const models = deps.models ?? FREEBUFF_MODELS.map((m) => m.id)
+  const models = deps.models ?? SUPPORTED_FREEBUFF_MODELS.map((m) => m.id)
 
   // One probe per tick covers every model — the Fireworks metrics endpoint
   // returns all deployments in a single response. Models without a dedicated
@@ -114,10 +117,13 @@ export async function runAdmissionTick(
   // advisory locks and a single update each.
   const perModel = await Promise.all(
     models.map(async (model) => {
-      const isRegisteredModel = FREEBUFF_MODELS.some((m) => m.id === model)
-      const health = !isRegisteredModel || isFreebuffModelAvailable(model, now)
-        ? fleet[model] ?? 'healthy'
-        : 'unhealthy'
+      const isRegisteredModel = SUPPORTED_FREEBUFF_MODELS.some(
+        (m) => m.id === model,
+      )
+      const health =
+        !isRegisteredModel || isFreebuffModelAvailable(model, now)
+          ? (fleet[model] ?? 'healthy')
+          : 'unhealthy'
       const { admitted, skipped } = await deps.admitFromQueue({
         model,
         sessionLengthMs: deps.sessionLengthMs,
@@ -184,16 +190,16 @@ function runTick() {
 export function startFreeSessionAdmission(): boolean {
   if (interval) return true
   if (!isWaitingRoomEnabled()) {
-    logger.info({}, '[FreeSessionAdmission] Waiting room disabled — ticker not started')
+    logger.info(
+      {},
+      '[FreeSessionAdmission] Waiting room disabled — ticker not started',
+    )
     return false
   }
   interval = setInterval(runTick, ADMISSION_TICK_MS)
   if (typeof interval.unref === 'function') interval.unref()
   runTick() // fire first tick immediately
-  logger.info(
-    { tickMs: ADMISSION_TICK_MS },
-    '[FreeSessionAdmission] Started',
-  )
+  logger.info({ tickMs: ADMISSION_TICK_MS }, '[FreeSessionAdmission] Started')
   return true
 }
 

--- a/web/src/server/free-session/config.ts
+++ b/web/src/server/free-session/config.ts
@@ -1,5 +1,6 @@
 import {
   FREEBUFF_GEMINI_PRO_MODEL_ID,
+  FREEBUFF_GLM_MODEL_ID,
   FREEBUFF_KIMI_MODEL_ID,
   FREEBUFF_MINIMAX_MODEL_ID,
 } from '@codebuff/common/constants/freebuff-models'
@@ -54,6 +55,7 @@ export function getSessionGraceMs(): number {
  */
 const INSTANT_ADMIT_CAPACITY: Record<string, number> = {
   [FREEBUFF_GEMINI_PRO_MODEL_ID]: 50,
+  [FREEBUFF_GLM_MODEL_ID]: 50,
   [FREEBUFF_KIMI_MODEL_ID]: 50,
   [FREEBUFF_MINIMAX_MODEL_ID]: 1000,
 }

--- a/web/src/server/free-session/config.ts
+++ b/web/src/server/free-session/config.ts
@@ -1,6 +1,6 @@
 import {
   FREEBUFF_GEMINI_PRO_MODEL_ID,
-  FREEBUFF_GLM_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
   FREEBUFF_MINIMAX_MODEL_ID,
 } from '@codebuff/common/constants/freebuff-models'
 import { env } from '@codebuff/internal/env'
@@ -54,7 +54,7 @@ export function getSessionGraceMs(): number {
  */
 const INSTANT_ADMIT_CAPACITY: Record<string, number> = {
   [FREEBUFF_GEMINI_PRO_MODEL_ID]: 50,
-  [FREEBUFF_GLM_MODEL_ID]: 50,
+  [FREEBUFF_KIMI_MODEL_ID]: 50,
   [FREEBUFF_MINIMAX_MODEL_ID]: 1000,
 }
 

--- a/web/src/server/free-session/public-api.ts
+++ b/web/src/server/free-session/public-api.ts
@@ -1,7 +1,7 @@
 import {
   FREEBUFF_DEPLOYMENT_HOURS_LABEL,
   FREEBUFF_GEMINI_PRO_MODEL_ID,
-  FREEBUFF_GLM_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
   isFreebuffModelAvailable,
   isFreebuffModelId as isSelectableFreebuffModel,
   resolveFreebuffModel,
@@ -48,7 +48,7 @@ import type {
  */
 const RATE_LIMITS: Record<string, { limit: number; windowHours: number }> = {
   [FREEBUFF_GEMINI_PRO_MODEL_ID]: { limit: 1, windowHours: 24 },
-  [FREEBUFF_GLM_MODEL_ID]: { limit: 5, windowHours: 12 },
+  [FREEBUFF_KIMI_MODEL_ID]: { limit: 5, windowHours: 12 },
 }
 
 /** Fetch the caller's current quota snapshot for `model`, or undefined if the

--- a/web/src/server/free-session/public-api.ts
+++ b/web/src/server/free-session/public-api.ts
@@ -1,10 +1,11 @@
 import {
   FREEBUFF_DEPLOYMENT_HOURS_LABEL,
   FREEBUFF_GEMINI_PRO_MODEL_ID,
+  FREEBUFF_GLM_MODEL_ID,
   FREEBUFF_KIMI_MODEL_ID,
   isFreebuffModelAvailable,
-  isFreebuffModelId as isSelectableFreebuffModel,
-  resolveFreebuffModel,
+  isSupportedFreebuffModelId,
+  resolveSupportedFreebuffModel,
 } from '@codebuff/common/constants/freebuff-models'
 
 import {
@@ -48,6 +49,7 @@ import type {
  */
 const RATE_LIMITS: Record<string, { limit: number; windowHours: number }> = {
   [FREEBUFF_GEMINI_PRO_MODEL_ID]: { limit: 1, windowHours: 24 },
+  [FREEBUFF_GLM_MODEL_ID]: { limit: 5, windowHours: 12 },
   [FREEBUFF_KIMI_MODEL_ID]: { limit: 5, windowHours: 12 },
 }
 
@@ -241,7 +243,7 @@ export async function requestSession(params: {
   deps?: SessionDeps
 }): Promise<RequestSessionResult> {
   const deps = params.deps ?? defaultDeps
-  const model = resolveFreebuffModel(params.model)
+  const model = resolveSupportedFreebuffModel(params.model)
   const now = nowOf(deps)
   if (params.userBanned) {
     return { status: 'banned' }
@@ -251,13 +253,6 @@ export async function requestSession(params: {
     isWaitingRoomBypassedForEmail(params.userEmail)
   ) {
     return { status: 'disabled' }
-  }
-  if (!isFreebuffModelAvailable(model, now)) {
-    return {
-      status: 'model_unavailable',
-      requestedModel: model,
-      availableHours: FREEBUFF_DEPLOYMENT_HOURS_LABEL,
-    }
   }
 
   // Rate-limit check runs before joinOrTakeOver so heavy users never even
@@ -278,6 +273,14 @@ export async function requestSession(params: {
       (existing.status === 'active' &&
         !!existing.expires_at &&
         existing.expires_at.getTime() > now.getTime()))
+
+  if (!isReclaim && !isFreebuffModelAvailable(model, now)) {
+    return {
+      status: 'model_unavailable',
+      requestedModel: model,
+      availableHours: FREEBUFF_DEPLOYMENT_HOURS_LABEL,
+    }
+  }
 
   if (!isReclaim) {
     const snapshot = await fetchRateLimitSnapshot(params.userId, model, deps)
@@ -547,11 +550,11 @@ export async function checkSessionAdmissible(params: {
   // Reject requests for a model the session isn't bound to. Sub-agents may
   // legitimately use other models (Gemini Flash etc.) so we only enforce this
   // when the caller provides a requestedModel — and only against the set of
-  // selectable freebuff models (resolveFreebuffModel returns the canonical id
-  // or the default for anything outside the registry).
+  // supported freebuff models. This includes legacy ids so in-flight sessions
+  // created by older clients stay bound to the model they actually requested.
   if (
     params.requestedModel &&
-    isSelectableFreebuffModel(params.requestedModel) &&
+    isSupportedFreebuffModelId(params.requestedModel) &&
     params.requestedModel !== row.model
   ) {
     return {

--- a/web/src/server/free-session/store.ts
+++ b/web/src/server/free-session/store.ts
@@ -466,7 +466,7 @@ export async function promoteQueuedUser(params: {
  * the oldest is needed to compute `retryAfterMs` when the window is full,
  * so one query covers both the check and the reject path.
  *
- * Drives the per-user, per-model rate limit (e.g. at most 5 GLM sessions in
+ * Drives the per-user, per-model rate limit (e.g. at most 5 Kimi sessions in
  * the last 12h) enforced before `joinOrTakeOver`.
  */
 export async function listRecentAdmits(params: {


### PR DESCRIPTION
Switch Freebuff and lite-mode defaults from GLM 5.1 to Kimi K2.6 across agent definitions, selectable model config, free-mode allowlists, Fireworks routing/pricing, session quotas, UI copy, docs, and tests. Preserve the newer Gemini 3.1 Pro Freebuff option while making Kimi the default smartest deployment-hours model. Validation passed: focused Bun tests for agent/freebuff/fireworks/session paths and `bun run typecheck`. I also ran the full `bun run test`; it still fails on existing broad-suite setup issues (`TextEncoder` missing in Jest web LLM tests and missing generated CLI bundled agents).