### PR TITLE
Add service catalog tool renderer

### DIFF
--- a/cli/src/components/tools/__tests__/gravity-index.test.ts
+++ b/cli/src/components/tools/__tests__/gravity-index.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getGravityIndexDescription } from '../gravity-index'
+
+describe('getGravityIndexDescription', () => {
+  test('describes search queries', () => {
+    expect(
+      getGravityIndexDescription({
+        action: 'search',
+        query: 'transactional email for a Next.js app',
+      }),
+    ).toBe('Searching transactional email for a Next.js app')
+  })
+
+  test('describes browse category and keyword', () => {
+    expect(
+      getGravityIndexDescription({
+        action: 'browse',
+        category: 'Email',
+        q: 'send',
+      }),
+    ).toBe('Browsing Email for send')
+  })
+
+  test('describes service detail lookups', () => {
+    expect(
+      getGravityIndexDescription({
+        action: 'get_service',
+        slug: 'sendgrid',
+      }),
+    ).toBe('Getting sendgrid')
+  })
+
+  test('describes completed integration reports', () => {
+    expect(
+      getGravityIndexDescription({
+        action: 'report_integration',
+        integrated_slug: 'sendgrid',
+      }),
+    ).toBe('Reporting sendgrid integration')
+  })
+
+  test('uses fallback text for unknown input', () => {
+    expect(getGravityIndexDescription({ action: 'unknown' })).toBe(
+      'Using service catalog',
+    )
+    expect(getGravityIndexDescription(null)).toBe('Using service catalog')
+  })
+})

--- a/cli/src/components/tools/gravity-index.tsx
+++ b/cli/src/components/tools/gravity-index.tsx
@@ -1,0 +1,61 @@
+import { SimpleToolCallItem } from './tool-call-item'
+import { defineToolComponent } from './types'
+
+import type { ToolRenderConfig } from './types'
+
+const asTrimmedString = (value: unknown): string =>
+  typeof value === 'string' ? value.trim() : ''
+
+export const getGravityIndexDescription = (input: unknown): string => {
+  if (!input || typeof input !== 'object') {
+    return 'Using service catalog'
+  }
+
+  const params = input as Record<string, unknown>
+  const action = asTrimmedString(params.action)
+
+  switch (action) {
+    case 'search': {
+      const query = asTrimmedString(params.query)
+      return query ? `Searching ${query}` : 'Searching services'
+    }
+    case 'browse': {
+      const category = asTrimmedString(params.category)
+      const query = asTrimmedString(params.q)
+      return ['Browsing', category || 'services', query ? `for ${query}` : '']
+        .filter(Boolean)
+        .join(' ')
+    }
+    case 'list_categories':
+      return 'Listing service categories'
+    case 'get_service': {
+      const slug = asTrimmedString(params.slug)
+      return slug ? `Getting ${slug}` : 'Getting service details'
+    }
+    case 'report_integration': {
+      const slug = asTrimmedString(params.integrated_slug)
+      return slug ? `Reporting ${slug} integration` : 'Reporting integration'
+    }
+    default:
+      return 'Using service catalog'
+  }
+}
+
+/**
+ * UI component for gravity_index.
+ * Displays a one-line summary of what Gravity Index is searching or doing.
+ */
+export const GravityIndexComponent = defineToolComponent({
+  toolName: 'gravity_index',
+
+  render(toolBlock): ToolRenderConfig {
+    return {
+      content: (
+        <SimpleToolCallItem
+          name="Service Catalog"
+          description={getGravityIndexDescription(toolBlock.input)}
+        />
+      ),
+    }
+  },
+})

--- a/cli/src/components/tools/registry.ts
+++ b/cli/src/components/tools/registry.ts
@@ -1,6 +1,7 @@
 import { ApplyPatchComponent } from './apply-patch'
 import { CodeSearchComponent } from './code-search'
 import { GlobComponent } from './glob'
+import { GravityIndexComponent } from './gravity-index'
 import { ListDirectoryComponent } from './list-directory'
 import { ReadDocsComponent } from './read-docs'
 import { ReadFilesComponent } from './read-files'
@@ -30,6 +31,7 @@ const toolComponentRegistry = new Map<ToolName, ToolComponent>([
   [ApplyPatchComponent.toolName, ApplyPatchComponent],
   [CodeSearchComponent.toolName, CodeSearchComponent],
   [GlobComponent.toolName, GlobComponent],
+  [GravityIndexComponent.toolName, GravityIndexComponent],
   [ListDirectoryComponent.toolName, ListDirectoryComponent],
   [RunTerminalCommandComponent.toolName, RunTerminalCommandComponent],
   [ReadDocsComponent.toolName, ReadDocsComponent],


### PR DESCRIPTION
Adds a simple one-line CLI renderer for the gravity_index tool under the user-facing "Service Catalog" label.
It summarizes search, browse, category, service lookup, and integration reporting actions from the tool input.
Adds focused tests for the description helper and registers the renderer in the CLI tool registry.

Validation: bun run --cwd cli test src/components/tools/__tests__/gravity-index.test.ts; bun run --cwd cli typecheck.