### PR TITLE
Gate Kimi outside deployment hours

### DIFF
--- a/web/src/llm-api/fireworks.ts
+++ b/web/src/llm-api/fireworks.ts
@@ -39,11 +39,11 @@ const FIREWORKS_MODEL_MAP: Record<string, string> = {
   'z-ai/glm-5.1': 'accounts/fireworks/models/glm-5p1',
 }
 
-/** Models that stay limited to freebuff deployment hours even on serverless.
- *  Kimi/DeepSeek now run 24/7 via the freebuff selector; only legacy GLM 5.1
- *  is left under the deployment-hours gate so old clients hitting it during
- *  off-hours get a clear `model_unavailable` instead of a serverless surprise. */
-const FIREWORKS_HOURS_GATED_MODELS = new Set<string>(['z-ai/glm-5.1'])
+/** Models that stay limited to freebuff deployment hours even on serverless. */
+const FIREWORKS_HOURS_GATED_MODELS = new Set<string>([
+  'moonshotai/kimi-k2.6',
+  'z-ai/glm-5.1',
+])
 
 /** Flag to enable custom Fireworks deployments (set to false to use global API only) */
 const FIREWORKS_USE_CUSTOM_DEPLOYMENT = true


### PR DESCRIPTION
## Summary
- Add Kimi K2.6 to the Fireworks hours-gated model set so non-lite requests stay unavailable outside deployment hours.
- Keep lite-mode behavior intact so it can still fall back to the Fireworks standard API.

## Validation
- bun test web/src/llm-api/__tests__/fireworks-deployment.test.ts