### PR TITLE
Add Freebuff approved countries

### DIFF
--- a/freebuff/web/src/app/home-client.tsx
+++ b/freebuff/web/src/app/home-client.tsx
@@ -31,7 +31,7 @@ const faqs = [
   {
     question: 'Which countries is Freebuff available in?',
     answer:
-      'Freebuff is currently available in:\n\nUnited States, Canada, United Kingdom, Australia, New Zealand, Norway, Sweden, Netherlands, Denmark, Germany, Finland, Belgium, Luxembourg, Switzerland, Ireland, and Iceland.',
+      'Freebuff is currently available in:\n\nUnited States, Canada, United Kingdom, Australia, New Zealand, Norway, Sweden, Netherlands, Denmark, Germany, Finland, Belgium, Luxembourg, Liechtenstein, Switzerland, Austria, Singapore, Malta, Israel, Ireland, and Iceland.',
   },
   {
     question: 'Are you training on my data?',

--- a/web/src/server/__tests__/free-mode-country.test.ts
+++ b/web/src/server/__tests__/free-mode-country.test.ts
@@ -20,16 +20,25 @@ const noAnonymousNetwork = {
 const IPINFO_PRIVACY_TEST_IP = '198.51.100.42'
 
 describe('free mode country access', () => {
-  test('allows allowlisted Cloudflare countries', async () => {
+  test.each([
+    ['us', 'US'],
+    ['LU', 'LU'],
+    ['LI', 'LI'],
+    ['CH', 'CH'],
+    ['AT', 'AT'],
+    ['SG', 'SG'],
+    ['MT', 'MT'],
+    ['IL', 'IL'],
+  ])('allows allowlisted Cloudflare country %s', async (header, expected) => {
     const access = await getFreeModeCountryAccess(
       makeReq({
-        'cf-ipcountry': 'us',
+        'cf-ipcountry': header,
         'cf-connecting-ip': '203.0.113.10',
       }),
       noAnonymousNetwork,
     )
     expect(access.allowed).toBe(true)
-    expect(access.countryCode).toBe('US')
+    expect(access.countryCode).toBe(expected)
     expect(access.blockReason).toBe(null)
   })
 

--- a/web/src/server/free-mode-country.ts
+++ b/web/src/server/free-mode-country.ts
@@ -22,7 +22,12 @@ export const FREE_MODE_ALLOWED_COUNTRIES = new Set([
   'FI',
   'BE',
   'LU',
+  'LI',
   'CH',
+  'AT',
+  'SG',
+  'MT',
+  'IL',
   'IE',
   'IS',
 ])


### PR DESCRIPTION
Adds Austria, Singapore, Malta, Israel, and Liechtenstein to the Freebuff approved country allowlist while keeping Luxembourg covered. Updates the public Freebuff FAQ country list to match the server-side gate. Expands the country-access regression test to cover the newly approved country codes and existing Luxembourg/Switzerland coverage.

Validation: `bun test web/src/server/__tests__/free-mode-country.test.ts`, `bun --cwd web typecheck`, `bun --cwd freebuff/web typecheck`, and `bunx prettier --check web/src/server/free-mode-country.ts web/src/server/__tests__/free-mode-country.test.ts freebuff/web/src/app/home-client.tsx`.