### PR TITLE
Remove missing docs reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,4 +42,3 @@ IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning. Alway
 - `docs/environment-variables.md` — Env var rules, DI helpers, loading order
 - `docs/agents-and-tools.md` — Agent system, shell shims, tool definitions
 - `docs/patterns/handle-steps-generators.md` — handleSteps generator patterns and spawn_agents tool calls
-- `docs/patterns/discover-before-implement.md`


### PR DESCRIPTION
## Summary

- Remove the stale `docs/patterns/discover-before-implement.md` entry from `AGENTS.md`.

## Validation

- Confirmed the diff only removes the missing docs reference.
- No automated tests run; docs-only change.