### PR TITLE
Add Freebuff session restart option

### DIFF
--- a/cli/src/components/session-ended-banner.tsx
+++ b/cli/src/components/session-ended-banner.tsx
@@ -121,7 +121,7 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
             >
               {pendingAction === 'same-chat'
                 ? 'Starting…'
-                : 'Press Enter to continue with a new session'}
+                : 'Press Enter to continue in a new session'}
             </text>
           </Button>
           <box style={{ flexGrow: 1 }} />
@@ -148,7 +148,7 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
             >
               {pendingAction === 'waiting-room'
                 ? 'Opening model selection…'
-                : 'Back to model selection (ESC)'}
+                : 'Change model (ESC)'}
             </text>
           </Button>
         </box>

--- a/cli/src/components/session-ended-banner.tsx
+++ b/cli/src/components/session-ended-banner.tsx
@@ -21,8 +21,8 @@ interface SessionEndedBannerProps {
 
 /**
  * Replaces the chat input when the freebuff session has ended. Captures
- * Enter to re-queue the user; Esc keeps falling through to the global
- * stream-interrupt handler so in-flight work can be cancelled.
+ * Enter to start a new same-chat session. Esc returns to model selection
+ * once no in-flight work needs the global stream-interrupt handler.
  */
 export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
   isStreaming,
@@ -65,9 +65,14 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
         if (key.name === 'return' || key.name === 'enter') {
           key.preventDefault?.()
           startSameChatSession()
+          return
+        }
+        if (key.name === 'escape') {
+          key.preventDefault?.()
+          pickNewModel()
         }
       },
-      [startSameChatSession, canRestart],
+      [startSameChatSession, pickNewModel, canRestart],
     ),
   )
 
@@ -96,7 +101,14 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
           Agent is wrapping up. Rejoin the wait room after it's finished.
         </text>
       ) : (
-        <box style={{ flexDirection: 'row', gap: 2, flexWrap: 'wrap' }}>
+        <box
+          style={{
+            width: '100%',
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 2,
+          }}
+        >
           <Button onClick={startSameChatSession}>
             <text
               style={{
@@ -109,20 +121,34 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
             >
               {pendingAction === 'same-chat'
                 ? 'Starting…'
-                : 'Press Enter to start new session (same model + chat)'}
+                : 'Press Enter to continue with a new session'}
             </text>
           </Button>
-          <Button onClick={pickNewModel}>
+          <box style={{ flexGrow: 1 }} />
+          <Button
+            onClick={pickNewModel}
+            style={{
+              borderStyle: 'single',
+              borderColor:
+                pendingAction === 'waiting-room' ? theme.muted : theme.border,
+              customBorderChars: BORDER_CHARS,
+              paddingLeft: 1,
+              paddingRight: 1,
+            }}
+            border={['top', 'bottom', 'left', 'right']}
+          >
             <text
               style={{
                 fg:
-                  pendingAction === 'waiting-room' ? theme.muted : theme.info,
+                  pendingAction === 'waiting-room'
+                    ? theme.muted
+                    : theme.foreground,
               }}
               attributes={TextAttributes.BOLD}
             >
               {pendingAction === 'waiting-room'
-                ? 'Opening model picker…'
-                : 'Pick a new model'}
+                ? 'Opening model selection…'
+                : 'Back to model selection (ESC)'}
             </text>
           </Button>
         </box>

--- a/cli/src/components/session-ended-banner.tsx
+++ b/cli/src/components/session-ended-banner.tsx
@@ -3,7 +3,10 @@ import { useKeyboard } from '@opentui/react'
 import React, { useCallback, useState } from 'react'
 
 import { Button } from './button'
-import { returnToFreebuffLanding } from '../hooks/use-freebuff-session'
+import {
+  refreshFreebuffSession,
+  returnToFreebuffLanding,
+} from '../hooks/use-freebuff-session'
 import { useTheme } from '../hooks/use-theme'
 import { BORDER_CHARS } from '../utils/ui-constants'
 
@@ -25,36 +28,46 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
   isStreaming,
 }) => {
   const theme = useTheme()
-  const [rejoining, setRejoining] = useState(false)
+  const [pendingAction, setPendingAction] = useState<
+    'waiting-room' | 'same-chat' | null
+  >(null)
 
-  // While a request is still streaming, rejoin is disabled: it would
+  // While a request is still streaming, restart is disabled: it would
   // unmount <Chat> and abort the in-flight agent run. The promise is "we
   // let the agent finish" — honoring that means Enter does nothing until
   // the stream ends or the user hits Esc.
-  const canRejoin = !isStreaming && !rejoining
-  const rejoin = useCallback(() => {
-    if (!canRejoin) return
-    setRejoining(true)
+  const canRestart = !isStreaming && pendingAction === null
+  const pickNewModel = useCallback(() => {
+    if (!canRestart) return
+    setPendingAction('waiting-room')
     // Drop back to the landing picker (status: 'none') so the user picks a
     // model and hits Enter again to commit, instead of being silently
     // re-queued. app.tsx swaps us into <WaitingRoomScreen> on the
-    // transition, unmounting this banner — no need to clear `rejoining` on
+    // transition, unmounting this banner — no need to clear the pending state on
     // success.
     returnToFreebuffLanding({ resetChat: true }).catch(() =>
-      setRejoining(false),
+      setPendingAction(null),
     )
-  }, [canRejoin])
+  }, [canRestart])
+
+  const startSameChatSession = useCallback(() => {
+    if (!canRestart) return
+    setPendingAction('same-chat')
+    // Re-POST with the currently selected model and keep the chat/run state
+    // intact so the next prompt continues the same conversation.
+    refreshFreebuffSession().catch(() => setPendingAction(null))
+  }, [canRestart])
 
   useKeyboard(
     useCallback(
       (key: KeyEvent) => {
-        if (!canRejoin) return
+        if (!canRestart) return
         if (key.name === 'return' || key.name === 'enter') {
           key.preventDefault?.()
-          rejoin()
+          startSameChatSession()
         }
       },
-      [rejoin, canRejoin],
+      [startSameChatSession, canRestart],
     ),
   )
 
@@ -83,14 +96,36 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
           Agent is wrapping up. Rejoin the wait room after it's finished.
         </text>
       ) : (
-        <Button onClick={rejoin}>
-          <text
-            style={{ fg: rejoining ? theme.muted : theme.primary }}
-            attributes={TextAttributes.BOLD}
-          >
-            {rejoining ? 'Rejoining…' : 'Press Enter to rejoin waiting room'}
-          </text>
-        </Button>
+        <box style={{ flexDirection: 'row', gap: 2, flexWrap: 'wrap' }}>
+          <Button onClick={startSameChatSession}>
+            <text
+              style={{
+                fg:
+                  pendingAction === 'same-chat'
+                    ? theme.muted
+                    : theme.primary,
+              }}
+              attributes={TextAttributes.BOLD}
+            >
+              {pendingAction === 'same-chat'
+                ? 'Starting…'
+                : 'Press Enter to start new session (same model + chat)'}
+            </text>
+          </Button>
+          <Button onClick={pickNewModel}>
+            <text
+              style={{
+                fg:
+                  pendingAction === 'waiting-room' ? theme.muted : theme.info,
+              }}
+              attributes={TextAttributes.BOLD}
+            >
+              {pendingAction === 'waiting-room'
+                ? 'Opening model picker…'
+                : 'Pick a new model'}
+            </text>
+          </Button>
+        </box>
       )}
     </box>
   )

--- a/cli/src/hooks/use-freebuff-session.ts
+++ b/cli/src/hooks/use-freebuff-session.ts
@@ -460,7 +460,10 @@ export function useFreebuffSession(): UseFreebuffSessionResult {
           useFreebuffModelStore
             .getState()
             .setSelectedModel(FALLBACK_FREEBUFF_MODEL_ID)
-          nextMethod = 'GET'
+          // The unavailable response came from a POST attempt. Re-POST with
+          // the fallback model; a GET would only redisplay the old ended row
+          // and leave the restart banner stuck in its pending state.
+          nextMethod = 'POST'
           schedule(0)
           return
         }

--- a/cli/src/hooks/use-send-message.ts
+++ b/cli/src/hooks/use-send-message.ts
@@ -138,7 +138,9 @@ export const useSendMessage = ({
     setRunState,
     setIsRetrying,
   } = useChatStore.getState()
-  const previousRunStateRef = useRef<RunState | null>(null)
+  const previousRunStateRef = useRef<RunState | null>(
+    useChatStore.getState().runState,
+  )
   // Memoize stream controller to maintain referential stability across renders
   const streamRefsRef = useRef<ReturnType<
     typeof createStreamController
@@ -198,6 +200,7 @@ export const useSendMessage = ({
 
   function clearMessages() {
     previousRunStateRef.current = null
+    setRunState(null)
   }
 
   const prepareUserMessage = useCallback(


### PR DESCRIPTION
Adds a session-ended action that lets Freebuff users start another session with the same model and conversation history, with Enter mapped to that default flow. Keeps a secondary button for returning to model selection when the user wants to pick a different model. Preserves SDK run state across Chat remounts after waiting-room admission and clears it when starting a genuinely new chat. Validation: git diff --check and per-file Bun transpilation passed; full CLI typecheck was not runnable in this workspace because dependencies/types are missing.