### PR TITLE
Fix auth code expiry parsing

### DIFF
--- a/freebuff/web/src/app/login/page.tsx
+++ b/freebuff/web/src/app/login/page.tsx
@@ -12,6 +12,7 @@ import {
   CardDescription,
   CardContent,
 } from '@/components/ui/card'
+import { isAuthCodeExpired, parseAuthCode } from '@/app/onboard/_helpers'
 
 export default async function LoginPage({
   searchParams,
@@ -22,10 +23,9 @@ export default async function LoginPage({
   const authCode = resolvedSearchParams?.auth_code as string | undefined
 
   if (authCode) {
-    const [_fingerprintId, expiresAt, _receivedFingerprintHash] =
-      authCode.split('.')
+    const { expiresAt } = parseAuthCode(authCode)
 
-    if (parseInt(expiresAt) < Date.now()) {
+    if (expiresAt && isAuthCodeExpired(expiresAt)) {
       return (
         <div className="relative min-h-screen overflow-hidden">
           <div className="absolute inset-0 bg-gradient-to-b from-dark-forest-green via-black/95 to-black" />
@@ -36,7 +36,9 @@ export default async function LoginPage({
             <div className="w-full sm:w-1/2 md:w-1/3">
               <Card className="border-zinc-800/80 bg-zinc-950/80 backdrop-blur-sm">
                 <CardHeader>
-                  <CardTitle className="text-white">Auth code expired</CardTitle>
+                  <CardTitle className="text-white">
+                    Auth code expired
+                  </CardTitle>
                   <CardDescription>
                     Please try starting Freebuff in your terminal again.
                   </CardDescription>

--- a/freebuff/web/src/app/onboard/__tests__/helpers.test.ts
+++ b/freebuff/web/src/app/onboard/__tests__/helpers.test.ts
@@ -1,0 +1,96 @@
+import { genAuthCode } from '@codebuff/common/util/credentials'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { parseAuthCode, validateAuthCode, isAuthCodeExpired } from '../_helpers'
+
+describe('freebuff onboard/_helpers', () => {
+  describe('parseAuthCode', () => {
+    test('parses valid auth code with three parts', () => {
+      const authCode = 'fingerprint-123.1704067200000.abc123hash'
+      const result = parseAuthCode(authCode)
+
+      expect(result.fingerprintId).toBe('fingerprint-123')
+      expect(result.expiresAt).toBe('1704067200000')
+      expect(result.receivedHash).toBe('abc123hash')
+    })
+
+    test('handles auth code with dots in fingerprint id', () => {
+      const authCode = 'fp.with.dots.1704067200000.hashvalue'
+      const result = parseAuthCode(authCode)
+
+      expect(result.fingerprintId).toBe('fp.with.dots')
+      expect(result.expiresAt).toBe('1704067200000')
+      expect(result.receivedHash).toBe('hashvalue')
+    })
+
+    test('handles auth code missing separator before expiresAt', () => {
+      const authCode =
+        'fingerprint-1231704067200000.abc123hashabc123hashabc123hash'
+      const result = parseAuthCode(authCode)
+
+      expect(result.fingerprintId).toBe('')
+      expect(result.expiresAt).toBe('')
+      expect(result.receivedHash).toBe('')
+    })
+  })
+
+  describe('validateAuthCode', () => {
+    const testSecret = 'test-secret-key'
+    const testFingerprintId = 'fp-abc123'
+    const testExpiresAt = '1704067200000'
+
+    test('returns valid=true when hash matches', () => {
+      const expectedHash = genAuthCode(
+        testFingerprintId,
+        testExpiresAt,
+        testSecret,
+      )
+      const result = validateAuthCode(
+        expectedHash,
+        testFingerprintId,
+        testExpiresAt,
+        testSecret,
+      )
+
+      expect(result.valid).toBe(true)
+      expect(result.expectedHash).toBe(expectedHash)
+    })
+
+    test('returns valid=false when hash does not match', () => {
+      const result = validateAuthCode(
+        'wrong-hash-value',
+        testFingerprintId,
+        testExpiresAt,
+        testSecret,
+      )
+
+      expect(result.valid).toBe(false)
+    })
+  })
+
+  describe('isAuthCodeExpired', () => {
+    let originalDateNow: typeof Date.now
+
+    beforeEach(() => {
+      originalDateNow = Date.now
+    })
+
+    afterEach(() => {
+      Date.now = originalDateNow
+    })
+
+    test('returns true when expiresAt is in the past', () => {
+      Date.now = () => 1704067200000
+      expect(isAuthCodeExpired('1704067199999')).toBe(true)
+    })
+
+    test('returns false when expiresAt is in the future', () => {
+      Date.now = () => 1704067200000
+      expect(isAuthCodeExpired('1704067200001')).toBe(false)
+    })
+
+    test('treats malformed timestamps as expired', () => {
+      expect(isAuthCodeExpired('not-a-number')).toBe(true)
+    })
+  })
+})

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -10,6 +10,7 @@ import {
   CardDescription,
   CardContent,
 } from '@/components/ui/card'
+import { isAuthCodeExpired, parseAuthCode } from '@/app/onboard/_helpers'
 
 // Server component that handles the auth code expiration check
 export default async function LoginPage({
@@ -21,11 +22,10 @@ export default async function LoginPage({
   const authCode = resolvedSearchParams?.auth_code as string | undefined
 
   if (authCode) {
-    const [_fingerprintId, expiresAt, _receivedfingerprintHash] =
-      authCode.split('.')
+    const { expiresAt } = parseAuthCode(authCode)
 
     // Check for token expiration on the server side
-    if (parseInt(expiresAt) < Date.now()) {
+    if (expiresAt && isAuthCodeExpired(expiresAt)) {
       return (
         <Card>
           <CardHeader>

--- a/web/src/app/onboard/__tests__/helpers.test.ts
+++ b/web/src/app/onboard/__tests__/helpers.test.ts
@@ -32,6 +32,16 @@ describe('onboard/_helpers', () => {
       expect(result.receivedHash).toBe('abc123hash')
     })
 
+    test('handles auth code missing separator before expiresAt', () => {
+      const authCode =
+        'fingerprint-1231704067200000.abc123hashabc123hashabc123hash'
+      const result = parseAuthCode(authCode)
+
+      expect(result.fingerprintId).toBe('')
+      expect(result.expiresAt).toBe('')
+      expect(result.receivedHash).toBe('')
+    })
+
     test('handles empty string parts', () => {
       const authCode = '..emptyparts'
       const result = parseAuthCode(authCode)


### PR DESCRIPTION
## Summary

Use the shared auth-code parser for login-page expiry checks in both Codebuff and Freebuff instead of splitting on dots directly. This keeps `/login` consistent with `/onboard`, including fingerprints that contain dots and malformed auth-code handling. Adds focused Freebuff helper coverage and extends the existing web helper tests.

## Checks

- `bun test web/src/app/onboard/__tests__/helpers.test.ts`
- `bun test freebuff/web/src/app/onboard/__tests__/helpers.test.ts`
- `bun run --cwd freebuff/web typecheck`
- `bun run --cwd web typecheck`