### PR TITLE
[codex] Disable CLI diff rendering

### DIFF
--- a/cli/src/components/tools/__tests__/apply-patch.test.tsx
+++ b/cli/src/components/tools/__tests__/apply-patch.test.tsx
@@ -47,7 +47,7 @@ describe('ApplyPatchComponent', () => {
     expect(markup).toContain('src/new-file.ts')
   })
 
-  test('renders update_file operation with diff content', () => {
+  test('renders update_file operation without diff content while diff rendering is disabled', () => {
     const toolBlock = createToolBlock({
       type: 'update_file',
       path: 'src/existing.ts',
@@ -62,8 +62,8 @@ describe('ApplyPatchComponent', () => {
     const markup = renderToStaticMarkup(result?.content as React.ReactElement)
     expect(markup).toContain('Edit')
     expect(markup).toContain('src/existing.ts')
-    expect(markup).toContain('-oldLine')
-    expect(markup).toContain('+newLine')
+    expect(markup).not.toContain('-oldLine')
+    expect(markup).not.toContain('+newLine')
   })
 
   test('renders delete_file operation', () => {

--- a/cli/src/components/tools/diff-viewer.tsx
+++ b/cli/src/components/tools/diff-viewer.tsx
@@ -6,6 +6,8 @@ interface DiffViewerProps {
   diffText: string
 }
 
+const RENDER_DIFFS = false
+
 const DIFF_LINE_COLORS = {
   dark: {
     added: '#7ACC35',
@@ -50,6 +52,11 @@ const lineColor = (
 
 export const DiffViewer = ({ diffText }: DiffViewerProps) => {
   const theme = useTheme()
+
+  if (!RENDER_DIFFS) {
+    return null
+  }
+
   const lines = diffText.trim().split('\n')
 
   return (


### PR DESCRIPTION
## Summary

Disables rendered CLI diff output behind a single `RENDER_DIFFS` flag while leaving the existing rendering code in place for easy re-enablement. This avoids the suspected OpenTUI blank/crash path where completed edit tools render large persisted diffs after task completion or resume. Updates the apply-patch renderer test to match the temporarily disabled diff UI.

## Validation

- `bun test cli/src/components/tools/__tests__/apply-patch.test.tsx cli/src/utils/__tests__/implementor-helpers.test.ts`
- `bun --filter @codebuff/cli typecheck`