### PR TITLE
Fix CLI login URL origin

### DIFF
--- a/freebuff/web/src/app/api/auth/cli/code/__tests__/origin.test.ts
+++ b/freebuff/web/src/app/api/auth/cli/code/__tests__/origin.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getLoginUrlOrigin } from '../_origin'
+
+describe('api/auth/cli/code/_origin', () => {
+  test('uses the configured public app URL over the request origin', () => {
+    const req = new Request('https://localhost:10000/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(
+        req,
+        'https://freebuff.com',
+        'https://freebuff.com',
+        false,
+      ),
+    ).toBe('https://freebuff.com')
+  })
+
+  test('ignores a localhost configured URL in production', () => {
+    const req = new Request('https://localhost:10000/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(
+        req,
+        'https://localhost:10000',
+        'https://freebuff.com',
+        false,
+      ),
+    ).toBe('https://freebuff.com')
+  })
+
+  test('allows a localhost configured URL outside production', () => {
+    const req = new Request('http://localhost:3002/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(
+        req,
+        'http://localhost:3002',
+        'https://freebuff.com',
+        true,
+      ),
+    ).toBe('http://localhost:3002')
+  })
+
+  test('falls back to the request origin when configured URL is invalid', () => {
+    const req = new Request('http://localhost:3002/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(req, 'not a url', 'https://freebuff.com', true),
+    ).toBe('http://localhost:3002')
+  })
+})

--- a/freebuff/web/src/app/api/auth/cli/code/_origin.ts
+++ b/freebuff/web/src/app/api/auth/cli/code/_origin.ts
@@ -1,0 +1,31 @@
+export function getLoginUrlOrigin(
+  req: Request,
+  configuredAppUrl: string,
+  fallbackOrigin: string,
+  allowLocalhost: boolean,
+): string {
+  const configuredOrigin = getUsableOrigin(configuredAppUrl, allowLocalhost)
+  if (configuredOrigin) {
+    return configuredOrigin
+  }
+
+  return getUsableOrigin(req.url, allowLocalhost) ?? fallbackOrigin
+}
+
+function getUsableOrigin(url: string, allowLocalhost: boolean) {
+  try {
+    const parsedUrl = new URL(url)
+    if (!allowLocalhost && isLocalhost(parsedUrl.hostname)) {
+      return null
+    }
+    return parsedUrl.origin
+  } catch {
+    return null
+  }
+}
+
+function isLocalhost(hostname: string) {
+  return (
+    hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
+  )
+}

--- a/freebuff/web/src/app/api/auth/cli/code/route.ts
+++ b/freebuff/web/src/app/api/auth/cli/code/route.ts
@@ -8,6 +8,8 @@ import { z } from 'zod/v4'
 
 import { logger } from '@/util/logger'
 
+import { getLoginUrlOrigin } from './_origin'
+
 export async function POST(req: Request) {
   const reqSchema = z.object({
     fingerprintId: z.string(),
@@ -53,9 +55,15 @@ export async function POST(req: Request) {
       )
     }
 
-    // Generate login URL on the same origin that issued the auth code. This
-    // avoids bouncing between apex/www hosts during the browser OAuth flow.
-    const loginUrl = new URL('/login', new URL(req.url).origin)
+    const loginUrl = new URL(
+      '/login',
+      getLoginUrlOrigin(
+        req,
+        env.NEXT_PUBLIC_CODEBUFF_APP_URL,
+        'https://freebuff.com',
+        env.NEXT_PUBLIC_CB_ENVIRONMENT !== 'prod',
+      ),
+    )
     loginUrl.searchParams.set(
       'auth_code',
       `${fingerprintId}.${expiresAt}.${fingerprintHash}`,

--- a/web/src/app/api/auth/cli/code/__tests__/origin.test.ts
+++ b/web/src/app/api/auth/cli/code/__tests__/origin.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getLoginUrlOrigin } from '../_origin'
+
+describe('api/auth/cli/code/_origin', () => {
+  test('uses the configured public app URL over the request origin', () => {
+    const req = new Request('https://localhost:10000/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(
+        req,
+        'https://www.codebuff.com',
+        'https://codebuff.com',
+        false,
+      ),
+    ).toBe('https://www.codebuff.com')
+  })
+
+  test('ignores a localhost configured URL in production', () => {
+    const req = new Request('https://localhost:10000/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(
+        req,
+        'https://localhost:10000',
+        'https://codebuff.com',
+        false,
+      ),
+    ).toBe('https://codebuff.com')
+  })
+
+  test('allows a localhost configured URL outside production', () => {
+    const req = new Request('http://localhost:3000/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(
+        req,
+        'http://localhost:3000',
+        'https://codebuff.com',
+        true,
+      ),
+    ).toBe('http://localhost:3000')
+  })
+
+  test('falls back to the request origin when configured URL is invalid', () => {
+    const req = new Request('http://localhost:3000/api/auth/cli/code')
+
+    expect(
+      getLoginUrlOrigin(req, 'not a url', 'https://codebuff.com', true),
+    ).toBe('http://localhost:3000')
+  })
+})

--- a/web/src/app/api/auth/cli/code/_origin.ts
+++ b/web/src/app/api/auth/cli/code/_origin.ts
@@ -1,0 +1,31 @@
+export function getLoginUrlOrigin(
+  req: Request,
+  configuredAppUrl: string,
+  fallbackOrigin: string,
+  allowLocalhost: boolean,
+): string {
+  const configuredOrigin = getUsableOrigin(configuredAppUrl, allowLocalhost)
+  if (configuredOrigin) {
+    return configuredOrigin
+  }
+
+  return getUsableOrigin(req.url, allowLocalhost) ?? fallbackOrigin
+}
+
+function getUsableOrigin(url: string, allowLocalhost: boolean) {
+  try {
+    const parsedUrl = new URL(url)
+    if (!allowLocalhost && isLocalhost(parsedUrl.hostname)) {
+      return null
+    }
+    return parsedUrl.origin
+  } catch {
+    return null
+  }
+}
+
+function isLocalhost(hostname: string) {
+  return (
+    hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
+  )
+}

--- a/web/src/app/api/auth/cli/code/route.ts
+++ b/web/src/app/api/auth/cli/code/route.ts
@@ -8,6 +8,8 @@ import { z } from 'zod/v4'
 
 import { logger } from '@/util/logger'
 
+import { getLoginUrlOrigin } from './_origin'
+
 export async function POST(req: Request) {
   const reqSchema = z.object({
     fingerprintId: z.string(),
@@ -55,9 +57,15 @@ export async function POST(req: Request) {
       )
     }
 
-    // Generate login URL on the same origin that issued the auth code. This
-    // avoids bouncing between apex/www hosts during the browser OAuth flow.
-    const loginUrl = new URL('/login', new URL(req.url).origin)
+    const loginUrl = new URL(
+      '/login',
+      getLoginUrlOrigin(
+        req,
+        env.NEXT_PUBLIC_CODEBUFF_APP_URL,
+        'https://codebuff.com',
+        env.NEXT_PUBLIC_CB_ENVIRONMENT !== 'prod',
+      ),
+    )
     loginUrl.searchParams.set(
       'auth_code',
       `${fingerprintId}.${expiresAt}.${fingerprintHash}`,


### PR DESCRIPTION
## Summary
- Build CLI auth login links from the configured public app URL instead of blindly using the request URL origin
- In production, ignore localhost origins from either deployment config or request URL and fall back to the canonical public site
- Add Freebuff and Codebuff route-origin tests for the localhost deployment symptom

## Test plan
- bun test freebuff/web/src/app/api/auth/cli/code/__tests__/origin.test.ts
- bun test web/src/app/api/auth/cli/code/__tests__/origin.test.ts
- bun run --cwd freebuff/web typecheck
- bun run --cwd web typecheck
- git diff --check