### PR TITLE
[codex] Allow legacy free reviewer lite models

### DIFF
--- a/common/src/__tests__/free-agents.test.ts
+++ b/common/src/__tests__/free-agents.test.ts
@@ -68,6 +68,24 @@ describe('free mode agent model allowlist', () => {
     ).toBe(true)
   })
 
+  test('allows legacy code-reviewer-lite with freebuff reviewer models', () => {
+    expect(
+      isFreeModeAllowedAgentModel(
+        'code-reviewer-lite',
+        FREEBUFF_MINIMAX_MODEL_ID,
+      ),
+    ).toBe(true)
+    expect(
+      isFreeModeAllowedAgentModel('code-reviewer-lite', FREEBUFF_KIMI_MODEL_ID),
+    ).toBe(true)
+    expect(
+      isFreeModeAllowedAgentModel(
+        'code-reviewer-lite',
+        FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
+      ),
+    ).toBe(true)
+  })
+
   test('allows the browser-use subagent with its bundled model', () => {
     expect(
       isFreeModeAllowedAgentModel(

--- a/common/src/constants/free-agents.ts
+++ b/common/src/constants/free-agents.ts
@@ -88,6 +88,13 @@ export const FREE_MODE_AGENT_MODELS: Record<string, Set<string>> = {
   ]),
   'code-reviewer-kimi': new Set([FREEBUFF_KIMI_MODEL_ID]),
   'code-reviewer-deepseek': new Set([FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID]),
+  // Legacy freebuff clients spawned code-reviewer-lite under provider-specific
+  // free roots before those reviewer IDs existed.
+  'code-reviewer-lite': new Set([
+    FREEBUFF_MINIMAX_MODEL_ID,
+    FREEBUFF_KIMI_MODEL_ID,
+    FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
+  ]),
 
   // Legacy: kept for the standalone gemini thinker agent if invoked directly.
   [FREEBUFF_GEMINI_THINKER_AGENT_ID]: new Set([FREEBUFF_GEMINI_PRO_MODEL_ID]),


### PR DESCRIPTION
## Summary

- Allow the legacy `code-reviewer-lite` agent ID to run in free mode with MiniMax, Kimi, and DeepSeek reviewer models.
- Add coverage for the legacy reviewer-lite allowlist behavior.

## Why

Older freebuff flows can still spawn `code-reviewer-lite`, even though newer free reviewer agents use provider-specific IDs like `code-reviewer-minimax`, `code-reviewer-kimi`, and `code-reviewer-deepseek`. Without this allowlist entry, those legacy reviewer requests can be rejected by the free-mode agent/model gate.

## Validation

- `bun test common/src/__tests__/free-agents.test.ts`