### PR TITLE
[codex] Match free reviewer to base2 model

### DIFF
--- a/agents/__tests__/base2.test.ts
+++ b/agents/__tests__/base2.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
+  FREEBUFF_KIMI_MODEL_ID,
+  FREEBUFF_MINIMAX_MODEL_ID,
+} from '@codebuff/common/constants/freebuff-models'
+
+import { createBase2 } from '../base2/base2'
+
+describe('base2 reviewer selection', () => {
+  test.each([
+    [FREEBUFF_MINIMAX_MODEL_ID, 'code-reviewer-minimax'],
+    [FREEBUFF_KIMI_MODEL_ID, 'code-reviewer-kimi'],
+    [FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID, 'code-reviewer-deepseek'],
+  ])('uses matching reviewer for model %p', (model, expectedReviewer) => {
+    const base2 = createBase2('free', { model })
+
+    expect(base2.spawnableAgents).toContain(expectedReviewer)
+    expect(base2.instructionsPrompt).toContain(`Spawn a ${expectedReviewer}`)
+    expect(base2.stepPrompt).toContain(`spawn a ${expectedReviewer}`)
+  })
+})

--- a/agents/base2/base2-free-deepseek.ts
+++ b/agents/base2/base2-free-deepseek.ts
@@ -6,7 +6,6 @@ const definition = {
   ...createBase2('free', {
     noAskUser: true,
     model: FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
-    freeCodeReviewerAgentId: 'code-reviewer-deepseek',
   }),
   id: 'base2-free-deepseek',
   displayName: 'Buffy the DeepSeek Free Orchestrator',

--- a/agents/base2/base2-free-kimi.ts
+++ b/agents/base2/base2-free-kimi.ts
@@ -5,7 +5,6 @@ import { createBase2 } from './base2'
 const definition = {
   ...createBase2('free', {
     model: FREEBUFF_KIMI_MODEL_ID,
-    freeCodeReviewerAgentId: 'code-reviewer-kimi',
   }),
   id: 'base2-free-kimi',
   displayName: 'Buffy the Kimi Free Orchestrator',

--- a/agents/base2/base2-free.ts
+++ b/agents/base2/base2-free.ts
@@ -1,9 +1,7 @@
 import { createBase2 } from './base2'
 
 const definition = {
-  ...createBase2('free', {
-    freeCodeReviewerAgentId: 'code-reviewer-minimax',
-  }),
+  ...createBase2('free'),
   id: 'base2-free',
   displayName: 'Buffy the Free Orchestrator',
 }

--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -5,6 +5,7 @@ import {
   FREEBUFF_GEMINI_THINKER_STEP_PROMPT,
   FREEBUFF_GEMINI_THINKER_SYSTEM_INSTRUCTION,
 } from '@codebuff/common/constants/freebuff-gemini-thinker'
+import { FREEBUFF_REVIEWER_AGENT_ID_BY_MODEL } from '@codebuff/common/constants/free-agents'
 import {
   canFreebuffModelSpawnGeminiThinker,
   FREEBUFF_MINIMAX_MODEL_ID,
@@ -24,7 +25,6 @@ export function createBase2(
     noAskUser?: boolean
     model?: SecretAgentDefinition['model']
     providerOptions?: SecretAgentDefinition['providerOptions']
-    freeCodeReviewerAgentId?: string
   },
 ): Omit<SecretAgentDefinition, 'id'> {
   const {
@@ -33,7 +33,6 @@ export function createBase2(
     noAskUser = false,
     model: modelOverride,
     providerOptions,
-    freeCodeReviewerAgentId = 'code-reviewer-lite',
   } = options ?? {}
   const isDefault = mode === 'default'
   const isFast = mode === 'fast'
@@ -56,6 +55,8 @@ export function createBase2(
   // reasoning. Fast MiniMax omits the extra round trip by construction.
   const hasFreeGeminiThinker =
     isFree && canFreebuffModelSpawnGeminiThinker(model)
+  const freeCodeReviewerAgentId =
+    FREEBUFF_REVIEWER_AGENT_ID_BY_MODEL[model] ?? 'code-reviewer-lite'
   const defaultProviderOptions = isFree
     ? {
         data_collection: 'deny' as const,


### PR DESCRIPTION
## Summary
- Derive the free/lite code reviewer inside base2 from the already-computed model using the shared freebuff reviewer map.
- Remove redundant reviewer overrides from the free base2 wrapper agents so they cannot drift from model selection.
- Add coverage for MiniMax, Kimi, and DeepSeek reviewer selection across spawnable agents and generated prompts.

## Validation
- bun test agents/__tests__/base2.test.ts
- bun run --cwd agents typecheck
- bun run --cwd agents test