### PR TITLE
Restore CLI diff viewer

### DIFF
--- a/cli/src/components/tools/__tests__/apply-patch.test.tsx
+++ b/cli/src/components/tools/__tests__/apply-patch.test.tsx
@@ -47,7 +47,7 @@ describe('ApplyPatchComponent', () => {
     expect(markup).toContain('src/new-file.ts')
   })
 
-  test('renders update_file operation without diff content while diff rendering is disabled', () => {
+  test('renders update_file operation with diff content', () => {
     const toolBlock = createToolBlock({
       type: 'update_file',
       path: 'src/existing.ts',
@@ -62,8 +62,8 @@ describe('ApplyPatchComponent', () => {
     const markup = renderToStaticMarkup(result?.content as React.ReactElement)
     expect(markup).toContain('Edit')
     expect(markup).toContain('src/existing.ts')
-    expect(markup).not.toContain('-oldLine')
-    expect(markup).not.toContain('+newLine')
+    expect(markup).toContain('-oldLine')
+    expect(markup).toContain('+newLine')
   })
 
   test('renders delete_file operation', () => {

--- a/cli/src/components/tools/diff-viewer.tsx
+++ b/cli/src/components/tools/diff-viewer.tsx
@@ -6,8 +6,6 @@ interface DiffViewerProps {
   diffText: string
 }
 
-const RENDER_DIFFS = false
-
 const DIFF_LINE_COLORS = {
   dark: {
     added: '#7ACC35',
@@ -52,10 +50,6 @@ const lineColor = (
 
 export const DiffViewer = ({ diffText }: DiffViewerProps) => {
   const theme = useTheme()
-
-  if (!RENDER_DIFFS) {
-    return null
-  }
 
   const lines = diffText.trim().split('\n')
 


### PR DESCRIPTION
Restores CLI diff rendering by removing the temporary `RENDER_DIFFS = false` guard in the shared diff viewer component. This brings diffs back anywhere the CLI already passes diff text, including apply patch, str replace, and implementor file rows. Updates the apply-patch component test to assert update diffs are visible again.

Validation: `bun test cli/src/components/tools/__tests__/apply-patch.test.tsx`; `bun run --cwd=cli typecheck`.