### PR TITLE
Use opaque CLI auth tokens

### DIFF
--- a/freebuff/web/src/app/api/auth/cli/code/route.ts
+++ b/freebuff/web/src/app/api/auth/cli/code/route.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto'
+
 import { genAuthCode } from '@codebuff/common/util/credentials'
 import db from '@codebuff/internal/db'
 import * as schema from '@codebuff/internal/db/schema'
@@ -55,6 +57,15 @@ export async function POST(req: Request) {
       )
     }
 
+    const authCode = `${fingerprintId}.${expiresAt}.${fingerprintHash}`
+    const loginToken = randomBytes(32).toString('base64url')
+
+    await db.insert(schema.verificationToken).values({
+      identifier: `cli-login:${loginToken}`,
+      token: authCode,
+      expires: new Date(expiresAt),
+    })
+
     const loginUrl = new URL(
       '/login',
       getLoginUrlOrigin(
@@ -64,10 +75,7 @@ export async function POST(req: Request) {
         env.NEXT_PUBLIC_CB_ENVIRONMENT !== 'prod',
       ),
     )
-    loginUrl.searchParams.set(
-      'auth_code',
-      `${fingerprintId}.${expiresAt}.${fingerprintHash}`,
-    )
+    loginUrl.searchParams.set('auth_code', loginToken)
 
     return NextResponse.json({
       fingerprintId,

--- a/freebuff/web/src/app/onboard/_db.ts
+++ b/freebuff/web/src/app/onboard/_db.ts
@@ -32,6 +32,23 @@ export async function hasCliSessionForAuthHash(
   return existing.length > 0
 }
 
+export async function getCliAuthCodeForToken(
+  authCodeToken: string,
+): Promise<string | null> {
+  const existing = await db
+    .select({ authCode: schema.verificationToken.token })
+    .from(schema.verificationToken)
+    .where(
+      and(
+        eq(schema.verificationToken.identifier, `cli-login:${authCodeToken}`),
+        gt(schema.verificationToken.expires, new Date()),
+      ),
+    )
+    .limit(1)
+
+  return existing[0]?.authCode ?? null
+}
+
 export async function checkFingerprintConflict(
   fingerprintId: string,
   userId: string,

--- a/freebuff/web/src/app/onboard/page.tsx
+++ b/freebuff/web/src/app/onboard/page.tsx
@@ -7,6 +7,7 @@ import { getServerSession } from 'next-auth'
 import {
   checkFingerprintConflict,
   createCliSession,
+  getCliAuthCodeForToken,
   getSessionTokenFromCookies,
   hasCliSessionForAuthHash,
 } from './_db'
@@ -91,7 +92,9 @@ const Onboard = async ({ searchParams }: PageProps) => {
     )
   }
 
-  const { fingerprintId, expiresAt, receivedHash } = parseAuthCode(authCode)
+  const resolvedAuthCode = (await getCliAuthCodeForToken(authCode)) ?? authCode
+  const { fingerprintId, expiresAt, receivedHash } =
+    parseAuthCode(resolvedAuthCode)
   const { valid, expectedHash: fingerprintHash } = validateAuthCode(
     receivedHash,
     fingerprintId,
@@ -103,6 +106,8 @@ const Onboard = async ({ searchParams }: PageProps) => {
     logger.warn(
       {
         authCodeLength: authCode.length,
+        resolvedAuthCode: resolvedAuthCode !== authCode,
+        resolvedAuthCodeLength: resolvedAuthCode.length,
         dotCount: authCode.match(/\./g)?.length ?? 0,
         hyphenCount: authCode.match(/-/g)?.length ?? 0,
         fingerprintIdPrefix: fingerprintId.slice(0, 24),

--- a/web/src/app/api/auth/cli/code/route.ts
+++ b/web/src/app/api/auth/cli/code/route.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto'
+
 import { genAuthCode } from '@codebuff/common/util/credentials'
 import db from '@codebuff/internal/db'
 import * as schema from '@codebuff/internal/db/schema'
@@ -57,6 +59,15 @@ export async function POST(req: Request) {
       )
     }
 
+    const authCode = `${fingerprintId}.${expiresAt}.${fingerprintHash}`
+    const loginToken = randomBytes(32).toString('base64url')
+
+    await db.insert(schema.verificationToken).values({
+      identifier: `cli-login:${loginToken}`,
+      token: authCode,
+      expires: new Date(expiresAt),
+    })
+
     const loginUrl = new URL(
       '/login',
       getLoginUrlOrigin(
@@ -66,10 +77,7 @@ export async function POST(req: Request) {
         env.NEXT_PUBLIC_CB_ENVIRONMENT !== 'prod',
       ),
     )
-    loginUrl.searchParams.set(
-      'auth_code',
-      `${fingerprintId}.${expiresAt}.${fingerprintHash}`,
-    )
+    loginUrl.searchParams.set('auth_code', loginToken)
 
     return NextResponse.json({
       fingerprintId,

--- a/web/src/app/onboard/_db.ts
+++ b/web/src/app/onboard/_db.ts
@@ -32,6 +32,23 @@ export async function hasCliSessionForAuthHash(
   return existing.length > 0
 }
 
+export async function getCliAuthCodeForToken(
+  authCodeToken: string,
+): Promise<string | null> {
+  const existing = await db
+    .select({ authCode: schema.verificationToken.token })
+    .from(schema.verificationToken)
+    .where(
+      and(
+        eq(schema.verificationToken.identifier, `cli-login:${authCodeToken}`),
+        gt(schema.verificationToken.expires, new Date()),
+      ),
+    )
+    .limit(1)
+
+  return existing[0]?.authCode ?? null
+}
+
 export async function checkFingerprintConflict(
   fingerprintId: string,
   userId: string,

--- a/web/src/app/onboard/page.tsx
+++ b/web/src/app/onboard/page.tsx
@@ -7,6 +7,7 @@ import { getServerSession } from 'next-auth'
 import {
   checkFingerprintConflict,
   createCliSession,
+  getCliAuthCodeForToken,
   getSessionTokenFromCookies,
   hasCliSessionForAuthHash,
 } from './_db'
@@ -48,7 +49,9 @@ const Onboard = async ({ searchParams }: PageProps) => {
     )
   }
 
-  const { fingerprintId, expiresAt, receivedHash } = parseAuthCode(authCode)
+  const resolvedAuthCode = (await getCliAuthCodeForToken(authCode)) ?? authCode
+  const { fingerprintId, expiresAt, receivedHash } =
+    parseAuthCode(resolvedAuthCode)
   const { valid, expectedHash: fingerprintHash } = validateAuthCode(
     receivedHash,
     fingerprintId,


### PR DESCRIPTION
Changes CLI login URLs to carry a short opaque auth token instead of the full fingerprint/expiry/hash payload.
The full signed auth payload is stored for one hour in the existing verificationToken table and resolved by /onboard before the existing hash and expiry validation, while old full auth_code URLs remain supported.
This directly addresses production reports where Freebuff receives 43-character auth_code values.

Validation: bun test web/src/app/onboard/__tests__/helpers.test.ts freebuff/web/src/app/onboard/__tests__/helpers.test.ts web/src/app/api/auth/cli/code/__tests__/_origin.test.ts freebuff/web/src/app/api/auth/cli/code/__tests__/_origin.test.ts; bun run typecheck in web and freebuff/web; git diff --check.