### PR TITLE
Log CLI auth token correlation fields

### DIFF
--- a/freebuff/web/src/app/api/auth/cli/code/route.ts
+++ b/freebuff/web/src/app/api/auth/cli/code/route.ts
@@ -8,7 +8,10 @@ import { and, eq, gt } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { z } from 'zod/v4'
 
-import { buildCliAuthCode } from '@/app/onboard/_helpers'
+import {
+  buildCliAuthCode,
+  getCliAuthCodeHashPrefix,
+} from '@/app/onboard/_helpers'
 import { logger } from '@/util/logger'
 
 import { getLoginUrlOrigin } from './_origin'
@@ -81,6 +84,25 @@ export async function POST(req: Request) {
       ),
     )
     loginUrl.searchParams.set('auth_code', loginToken)
+
+    logger.info(
+      {
+        authCodeTokenHashPrefix: getCliAuthCodeHashPrefix(loginToken),
+        authCodeTokenLength: loginToken.length,
+        fingerprintIdPrefix: fingerprintId.slice(0, 24),
+        fingerprintIdLength: fingerprintId.length,
+        expiresAt,
+        loginUrlOrigin: loginUrl.origin,
+        requestOrigin: new URL(req.url).origin,
+        requestHost: req.headers.get('host'),
+        forwardedHost: req.headers.get('x-forwarded-host'),
+        forwardedProto: req.headers.get('x-forwarded-proto'),
+        originHeader: req.headers.get('origin'),
+        configuredAppUrl: env.NEXT_PUBLIC_CODEBUFF_APP_URL,
+        environment: env.NEXT_PUBLIC_CB_ENVIRONMENT,
+      },
+      'Issued Freebuff CLI auth code token',
+    )
 
     return NextResponse.json({
       fingerprintId,

--- a/freebuff/web/src/app/onboard/__tests__/helpers.test.ts
+++ b/freebuff/web/src/app/onboard/__tests__/helpers.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import {
   buildCliAuthCode,
+  getCliAuthCodeHashPrefix,
   isAuthCodeExpired,
   isOpaqueCliAuthCodeToken,
   parseAuthCode,
@@ -108,6 +109,13 @@ describe('freebuff onboard/_helpers', () => {
       expect(isOpaqueCliAuthCodeToken(signedAuthCode)).toBe(false)
       expect(isOpaqueCliAuthCodeToken('A'.repeat(42))).toBe(false)
       expect(isOpaqueCliAuthCodeToken(`${'A'.repeat(42)}.`)).toBe(false)
+    })
+
+    test('hashes auth codes for log correlation without logging the token', () => {
+      expect(getCliAuthCodeHashPrefix('a'.repeat(43))).toBe('66d34fba71f8')
+      expect(getCliAuthCodeHashPrefix(` ${'a'.repeat(43)}\n`)).toBe(
+        '66d34fba71f8',
+      )
     })
 
     test('resolves an opaque browser token before validation', async () => {

--- a/freebuff/web/src/app/onboard/_helpers.ts
+++ b/freebuff/web/src/app/onboard/_helpers.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import { genAuthCode } from '@codebuff/common/util/credentials'
 
 const OPAQUE_CLI_AUTH_CODE_TOKEN_RE = /^[A-Za-z0-9_-]{43}$/
@@ -12,6 +14,10 @@ export function buildCliAuthCode(
 
 export function isOpaqueCliAuthCodeToken(authCode: string): boolean {
   return OPAQUE_CLI_AUTH_CODE_TOKEN_RE.test(authCode.trim())
+}
+
+export function getCliAuthCodeHashPrefix(authCode: string): string {
+  return createHash('sha256').update(authCode.trim()).digest('hex').slice(0, 12)
 }
 
 export async function resolveCliAuthCode(

--- a/freebuff/web/src/app/onboard/page.tsx
+++ b/freebuff/web/src/app/onboard/page.tsx
@@ -12,7 +12,9 @@ import {
   hasCliSessionForAuthHash,
 } from './_db'
 import {
+  getCliAuthCodeHashPrefix,
   isAuthCodeExpired,
+  isOpaqueCliAuthCodeToken,
   parseAuthCode,
   resolveCliAuthCode,
   validateAuthCode,
@@ -112,8 +114,12 @@ const Onboard = async ({ searchParams }: PageProps) => {
     logger.warn(
       {
         authCodeLength: authCode.length,
+        authCodeTrimmedLength: authCode.trim().length,
+        authCodeHashPrefix: getCliAuthCodeHashPrefix(authCode),
+        isOpaqueAuthCodeToken: isOpaqueCliAuthCodeToken(authCode),
         resolvedAuthCode: resolvedOpaqueToken,
         resolvedAuthCodeLength: resolvedAuthCode.length,
+        userId: user.id,
         dotCount: authCode.match(/\./g)?.length ?? 0,
         hyphenCount: authCode.match(/-/g)?.length ?? 0,
         fingerprintIdPrefix: fingerprintId.slice(0, 24),

--- a/web/src/app/api/auth/cli/code/route.ts
+++ b/web/src/app/api/auth/cli/code/route.ts
@@ -8,7 +8,10 @@ import { and, eq, gt } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { z } from 'zod/v4'
 
-import { buildCliAuthCode } from '@/app/onboard/_helpers'
+import {
+  buildCliAuthCode,
+  getCliAuthCodeHashPrefix,
+} from '@/app/onboard/_helpers'
 import { logger } from '@/util/logger'
 
 import { getLoginUrlOrigin } from './_origin'
@@ -83,6 +86,25 @@ export async function POST(req: Request) {
       ),
     )
     loginUrl.searchParams.set('auth_code', loginToken)
+
+    logger.info(
+      {
+        authCodeTokenHashPrefix: getCliAuthCodeHashPrefix(loginToken),
+        authCodeTokenLength: loginToken.length,
+        fingerprintIdPrefix: fingerprintId.slice(0, 24),
+        fingerprintIdLength: fingerprintId.length,
+        expiresAt,
+        loginUrlOrigin: loginUrl.origin,
+        requestOrigin: new URL(req.url).origin,
+        requestHost: req.headers.get('host'),
+        forwardedHost: req.headers.get('x-forwarded-host'),
+        forwardedProto: req.headers.get('x-forwarded-proto'),
+        originHeader: req.headers.get('origin'),
+        configuredAppUrl: env.NEXT_PUBLIC_CODEBUFF_APP_URL,
+        environment: env.NEXT_PUBLIC_CB_ENVIRONMENT,
+      },
+      'Issued Codebuff CLI auth code token',
+    )
 
     return NextResponse.json({
       fingerprintId,

--- a/web/src/app/onboard/__tests__/helpers.test.ts
+++ b/web/src/app/onboard/__tests__/helpers.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import {
   buildCliAuthCode,
+  getCliAuthCodeHashPrefix,
   isAuthCodeExpired,
   isOpaqueCliAuthCodeToken,
   parseAuthCode,
@@ -236,6 +237,13 @@ describe('onboard/_helpers', () => {
       expect(isOpaqueCliAuthCodeToken(signedAuthCode)).toBe(false)
       expect(isOpaqueCliAuthCodeToken('A'.repeat(42))).toBe(false)
       expect(isOpaqueCliAuthCodeToken(`${'A'.repeat(42)}.`)).toBe(false)
+    })
+
+    test('hashes auth codes for log correlation without logging the token', () => {
+      expect(getCliAuthCodeHashPrefix('a'.repeat(43))).toBe('66d34fba71f8')
+      expect(getCliAuthCodeHashPrefix(` ${'a'.repeat(43)}\n`)).toBe(
+        '66d34fba71f8',
+      )
     })
 
     test('resolves an opaque browser token before validation', async () => {

--- a/web/src/app/onboard/_helpers.ts
+++ b/web/src/app/onboard/_helpers.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import { genAuthCode } from '@codebuff/common/util/credentials'
 
 const OPAQUE_CLI_AUTH_CODE_TOKEN_RE = /^[A-Za-z0-9_-]{43}$/
@@ -12,6 +14,10 @@ export function buildCliAuthCode(
 
 export function isOpaqueCliAuthCodeToken(authCode: string): boolean {
   return OPAQUE_CLI_AUTH_CODE_TOKEN_RE.test(authCode.trim())
+}
+
+export function getCliAuthCodeHashPrefix(authCode: string): string {
+  return createHash('sha256').update(authCode.trim()).digest('hex').slice(0, 12)
 }
 
 export async function resolveCliAuthCode(


### PR DESCRIPTION
## Summary

- Add a SHA-256 auth-code hash prefix helper for safe log correlation without recording opaque login tokens.
- Log issued CLI auth token hash prefixes, token length, fingerprint prefix/length, URL origin, request forwarding headers, configured app URL, and environment in both Codebuff and Freebuff token issuance routes.
- Extend Freebuff invalid auth-code warnings with the auth-code hash prefix, trimmed length, opaque-token shape, and authenticated user id.

## Validation

- `bun test web/src/app/onboard/__tests__/helpers.test.ts freebuff/web/src/app/onboard/__tests__/helpers.test.ts web/src/app/api/auth/cli/code/__tests__/origin.test.ts freebuff/web/src/app/api/auth/cli/code/__tests__/origin.test.ts`
- `bunx prettier --check web/src/app/api/auth/cli/code/route.ts web/src/app/onboard/__tests__/helpers.test.ts web/src/app/onboard/_helpers.ts freebuff/web/src/app/api/auth/cli/code/route.ts freebuff/web/src/app/onboard/__tests__/helpers.test.ts freebuff/web/src/app/onboard/_helpers.ts freebuff/web/src/app/onboard/page.tsx`
- `bun run typecheck` in `web/`
- `bun run typecheck` in `freebuff/web/`
- `git diff --check`