### PR TITLE
Allow tmux-cli in free mode

### DIFF
--- a/common/src/__tests__/free-agents.test.ts
+++ b/common/src/__tests__/free-agents.test.ts
@@ -123,6 +123,24 @@ describe('free mode agent model allowlist', () => {
     ).toBe(true)
   })
 
+  test('allows the tmux-cli subagent with its bundled model', () => {
+    expect(
+      isFreeModeAllowedAgentModel('tmux-cli', FREEBUFF_MINIMAX_MODEL_ID),
+    ).toBe(true)
+    expect(
+      isFreeModeAllowedAgentModel(
+        'codebuff/tmux-cli@0.0.1',
+        FREEBUFF_MINIMAX_MODEL_ID,
+      ),
+    ).toBe(true)
+    expect(
+      isFreeModeAllowedAgentModel(
+        'other/tmux-cli@0.0.1',
+        FREEBUFF_MINIMAX_MODEL_ID,
+      ),
+    ).toBe(false)
+  })
+
   test('allows Gemini Pro for the thinker subagent but not the freebuff root', () => {
     expect(
       isFreeModeAllowedAgentModel('base2-free', FREEBUFF_GEMINI_PRO_MODEL_ID),

--- a/common/src/constants/free-agents.ts
+++ b/common/src/constants/free-agents.ts
@@ -91,6 +91,7 @@ export const FREE_MODE_AGENT_MODELS: Record<string, Set<string>> = {
 
   // Command execution
   basher: new Set(['google/gemini-3.1-flash-lite-preview']),
+  'tmux-cli': new Set([FREEBUFF_MINIMAX_MODEL_ID]),
 
   // Code reviewer for free mode
   'code-reviewer-minimax': new Set([


### PR DESCRIPTION
## Summary

Allow the bundled tmux-cli subagent to run in free mode using its MiniMax model. This lets all free root agents, including Kimi and DeepSeek variants, spawn tmux-cli without falling out of the free-mode allowlist. Added coverage for unscoped, codebuff-scoped, and spoofed publisher IDs.

## Validation

- bun test common/src/__tests__/free-agents.test.ts
- bun run --cwd common typecheck