### PR TITLE
[codex] Set Freebuff ad request user agent

### DIFF
--- a/cli/src/hooks/use-gravity-ad.ts
+++ b/cli/src/hooks/use-gravity-ad.ts
@@ -7,6 +7,7 @@ import { useChatStore } from '../state/chat-store'
 import { isUserActive, subscribeToActivity } from '../utils/activity-tracker'
 import { getAuthToken } from '../utils/auth'
 import { IS_FREEBUFF } from '../utils/constants'
+import { getCliEnv } from '../utils/env'
 import { logger } from '../utils/logger'
 
 import type { Message } from '@codebuff/sdk'
@@ -165,8 +166,12 @@ export const useGravityAd = (options?: {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${authToken}`,
+          'User-Agent': getCliAdRequestUserAgent(),
         },
-        body: JSON.stringify({ impUrl, mode: agentMode }),
+        body: JSON.stringify({
+          impUrl,
+          mode: agentMode,
+        }),
       })
 
       if (!res.ok) {
@@ -282,6 +287,7 @@ export const useGravityAd = (options?: {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${authToken}`,
+            'User-Agent': getCliAdRequestUserAgent(),
           },
           body: JSON.stringify({
             provider: providerToTry,
@@ -481,4 +487,10 @@ function getAdUserAgent(): string {
     linux: `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${AD_CHROME_VERSION} Safari/537.36`,
   }
   return osUA[process.platform] ?? osUA.linux
+}
+
+function getCliAdRequestUserAgent(): string {
+  const product = IS_FREEBUFF ? 'Freebuff-CLI' : 'Codebuff-CLI'
+  const version = getCliEnv().CODEBUFF_CLI_VERSION ?? 'dev'
+  return `${product}/${version}`
 }

--- a/web/src/app/api/v1/ads/_post.ts
+++ b/web/src/app/api/v1/ads/_post.ts
@@ -46,7 +46,7 @@ const bodySchema = z.object({
   sessionId: z.string().optional(),
   device: deviceSchema.optional(),
   surface: surfaceSchema.optional(),
-  /** Browser/CLI useragent passed through to providers that require it. */
+  /** Browser-like useragent passed through to providers that require it. */
   userAgent: z.string().optional(),
 })
 
@@ -120,6 +120,7 @@ export async function postAds(params: {
   const providerId: AdProviderId = parsedBody.provider ?? 'gravity'
   const userAgent =
     parsedBody.userAgent ?? req.headers.get('user-agent') ?? undefined
+  const requestUserAgent = req.headers.get('user-agent') ?? undefined
 
   // Pick a provider. If the requested one isn't configured, return no ad
   // rather than failing — the client falls back to its cache / fallback UI.
@@ -151,6 +152,7 @@ export async function postAds(params: {
       sessionId: parsedBody.sessionId,
       clientIp,
       userAgent,
+      requestUserAgent,
       device: parsedBody.device,
       surface: parsedBody.surface,
       messages: parsedBody.messages,

--- a/web/src/app/api/v1/ads/impression/_post.ts
+++ b/web/src/app/api/v1/ads/impression/_post.ts
@@ -183,11 +183,16 @@ export async function postAdImpression(params: {
       p.replaceAll('[timestamp]', now),
     )
     const pixelUrls = [impUrl, ...extraPixels]
+    const requestUserAgent = req.headers.get('user-agent') ?? undefined
 
     await Promise.all(
       pixelUrls.map(async (pixelUrl) => {
         try {
-          await fetch(pixelUrl)
+          await fetch(pixelUrl, {
+            ...(requestUserAgent
+              ? { headers: { 'User-Agent': requestUserAgent } }
+              : {}),
+          })
         } catch (error) {
           logger.warn(
             {

--- a/web/src/lib/ad-providers/__tests__/carbon.test.ts
+++ b/web/src/lib/ad-providers/__tests__/carbon.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createCarbonProvider } from '../carbon'
+
+import type { Logger } from '@codebuff/common/types/contracts/logger'
+
+const logger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
+
+describe('Carbon ad provider', () => {
+  test('sends the CLI User-Agent as the HTTP header', async () => {
+    const provider = createCarbonProvider({ zoneKey: 'CVADC53U' })
+    const requests: Array<{ url: string; init?: RequestInit }> = []
+    const fetch = Object.assign(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(url), init })
+        return new Response(
+          JSON.stringify({
+            ads: [
+              {
+                statlink: '//srv.buysellads.com/click',
+                statimp: '//srv.buysellads.com/imp',
+                description: 'Ad copy',
+                company: 'Acme',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        )
+      },
+      { preconnect: () => {} },
+    ) as typeof globalThis.fetch
+
+    const result = await provider.fetchAd({
+      userId: 'user-1',
+      userEmail: 'user@example.com',
+      clientIp: '203.0.113.1',
+      userAgent: 'Mozilla/5.0 Test Browser',
+      requestUserAgent: 'Freebuff-CLI/0.0.88',
+      messages: [],
+      testMode: false,
+      logger,
+      fetch,
+    })
+
+    expect(result?.ads).toHaveLength(1)
+    expect(requests).toHaveLength(4)
+    for (const request of requests) {
+      expect(request.url).toContain('useragent=Mozilla%2F5.0+Test+Browser')
+      expect(request.init?.headers).toEqual({
+        'User-Agent': 'Freebuff-CLI/0.0.88',
+      })
+    }
+  })
+})

--- a/web/src/lib/ad-providers/carbon.ts
+++ b/web/src/lib/ad-providers/carbon.ts
@@ -95,13 +95,12 @@ function normalizeCarbonAd(raw: CarbonAd): NormalizedAd | null {
   }
 }
 
-export function createCarbonProvider(config: {
-  zoneKey: string
-}): AdProvider {
+export function createCarbonProvider(config: { zoneKey: string }): AdProvider {
   return {
     id: 'carbon',
     fetchAd: async (input: FetchAdInput): Promise<FetchAdResult> => {
-      const { clientIp, userAgent, testMode, logger, fetch } = input
+      const { clientIp, userAgent, requestUserAgent, testMode, logger, fetch } =
+        input
 
       if (!clientIp || !userAgent) {
         logger.debug(
@@ -122,7 +121,12 @@ export function createCarbonProvider(config: {
       const url = `${CARBON_URL_BASE}/${config.zoneKey}.json?${params.toString()}`
 
       const fetchOne = async (): Promise<NormalizedAd | null> => {
-        const response = await fetch(url, { method: 'GET' })
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            'User-Agent': requestUserAgent ?? userAgent,
+          },
+        })
         if (!response.ok) {
           let body: unknown
           try {

--- a/web/src/lib/ad-providers/types.ts
+++ b/web/src/lib/ad-providers/types.ts
@@ -53,8 +53,10 @@ export type FetchAdInput = {
   sessionId?: string
   /** Client IP, parsed from X-Forwarded-For upstream. */
   clientIp?: string
-  /** Browser/CLI useragent string, passed through to upstream. */
+  /** Browser-like useragent string, passed through to upstream. */
   userAgent?: string
+  /** Product User-Agent header sent on provider HTTP requests. */
+  requestUserAgent?: string
   device?: AdDeviceInfo
   /** Product surface requesting the ad. Providers may map this to placements. */
   surface?: AdSurface


### PR DESCRIPTION
## Summary
Set the Freebuff/Codebuff CLI product `User-Agent` header on ad fetch and impression requests, then forward that header to Carbon ad-serving calls and impression pixel fetches. Carbon still receives the browser-like UA in its required `useragent` query parameter for targeting, while BuySellAds request logs now see `Freebuff-CLI/<version>` instead of the default Node UA. Added a Carbon provider test covering the forwarded header and required query parameter.

## Validation
Ran Carbon/ZeroClick provider tests, CLI typecheck, web typecheck, `git diff --check`, and a live `ignore=yes` request against the public Carbon test zone.