### PR TITLE
Fix freebuff model switch landing

### DIFF
--- a/cli/src/components/session-ended-banner.tsx
+++ b/cli/src/components/session-ended-banner.tsx
@@ -52,6 +52,12 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
   const bannerTitle = premiumQuota
     ? `Session ended  ·  ${formatSessionUnits(premiumQuota.recentCount)} of ${premiumQuota.limit} ${quotaLabel} used today`
     : 'Session ended'
+  const landingButtonLabel =
+    accessTier === 'limited' ? 'Back to start' : 'Change model'
+  const landingPendingLabel =
+    accessTier === 'limited'
+      ? 'Opening start screen…'
+      : 'Opening model selection…'
 
   // While a request is still streaming, restart is disabled: it would
   // unmount <Chat> and abort the in-flight agent run. The promise is "we
@@ -167,10 +173,11 @@ export const SessionEndedBanner: React.FC<SessionEndedBannerProps> = ({
               }}
             >
               {pendingAction === 'waiting-room' ? (
-                'Opening model selection…'
+                landingPendingLabel
               ) : (
                 <>
-                  Change model<span fg={theme.muted}>{'   Esc'}</span>
+                  {landingButtonLabel}
+                  <span fg={theme.muted}>{'   Esc'}</span>
                 </>
               )}
             </text>

--- a/cli/src/hooks/use-freebuff-session.ts
+++ b/cli/src/hooks/use-freebuff-session.ts
@@ -216,6 +216,25 @@ function shouldReleaseSlot(current: FreebuffSessionResponse | null): boolean {
   )
 }
 
+function toLandingSession(
+  current: FreebuffSessionResponse | null,
+): Extract<FreebuffSessionResponse, { status: 'none' }> {
+  const accessTier =
+    current && 'accessTier' in current ? current.accessTier : undefined
+  const queueDepthByModel =
+    current && 'queueDepthByModel' in current
+      ? current.queueDepthByModel
+      : undefined
+  const rateLimitsByModel = getRateLimitsByModel(current)
+
+  return {
+    status: 'none',
+    ...(accessTier ? { accessTier } : {}),
+    ...(queueDepthByModel ? { queueDepthByModel } : {}),
+    ...(rateLimitsByModel ? { rateLimitsByModel } : {}),
+  }
+}
+
 /** Best-effort DELETE of the caller's session row, gated on actually holding
  *  one. Used both by exit paths and any flow that wants the next POST to
  *  start clean (rejoin, return-to-landing). Always swallows errors — the
@@ -588,7 +607,10 @@ export function useFreebuffSession(): UseFreebuffSessionResult {
           // picker metadata from the response, ignoring whatever status it
           // claims. Polling resumes when the user commits to a model via
           // joinFreebuffQueue.
-          apply({ status: 'none' })
+          const landingSession = toLandingSession(
+            useFreebuffSessionStore.getState().session,
+          )
+          apply(landingSession)
           const fetchController = abortController
           callSession('GET', token, { signal: fetchController.signal })
             .then((response) => {
@@ -602,9 +624,14 @@ export function useFreebuffSession(): UseFreebuffSessionResult {
               if (response.status === 'none' || response.status === 'queued') {
                 apply({
                   status: 'none',
-                  accessTier: response.accessTier,
-                  queueDepthByModel: response.queueDepthByModel,
-                  rateLimitsByModel: response.rateLimitsByModel,
+                  accessTier:
+                    response.accessTier ?? landingSession.accessTier,
+                  queueDepthByModel:
+                    response.queueDepthByModel ??
+                    landingSession.queueDepthByModel,
+                  rateLimitsByModel:
+                    response.rateLimitsByModel ??
+                    landingSession.rateLimitsByModel,
                 })
               }
             })


### PR DESCRIPTION
Fixes the freebuff end-session flow so returning to the landing screen preserves known access-tier, queue, and quota metadata while fresh session metadata loads. This prevents the model selector from flashing briefly and then snapping back to the limited-tier start panel. The ended-session banner now labels the limited-tier path as "Back to start" instead of "Change model" because limited users only have one allowed model. Validated with `bun run typecheck` and `bun run test` in `cli/`.