### PR TITLE
Add /model aliases for mode commands

### DIFF
--- a/cli/src/commands/__tests__/router-input.test.ts
+++ b/cli/src/commands/__tests__/router-input.test.ts
@@ -210,6 +210,10 @@ describe('command-registry', () => {
       expect(credits).toBeDefined()
       expect(credits?.name).toBe('usage')
 
+      const modelDefault = findCommand('model:default')
+      expect(modelDefault).toBeDefined()
+      expect(modelDefault?.name).toBe('mode:default')
+
       const quit = findCommand('quit')
       expect(quit).toBeDefined()
       expect(quit?.name).toBe('exit')
@@ -267,6 +271,18 @@ describe('command-registry', () => {
         for (const alias of slashCommand.aliases ?? []) {
           expect(registered.has(alias)).toBe(true)
         }
+      }
+    })
+
+    test('mode commands expose model aliases for slash suggestions', () => {
+      const modeCommands = SLASH_COMMANDS.filter((cmd) =>
+        cmd.id.startsWith('mode:'),
+      )
+      expect(modeCommands.length).toBeGreaterThan(0)
+
+      for (const command of modeCommands) {
+        const modeName = command.id.slice('mode:'.length)
+        expect(command.aliases).toContain(`model:${modeName}`)
       }
     })
 

--- a/cli/src/commands/command-registry.ts
+++ b/cli/src/commands/command-registry.ts
@@ -396,6 +396,7 @@ const ALL_COMMANDS: CommandDefinition[] = [
   ...(IS_FREEBUFF ? [] : AGENT_MODES).map((mode) =>
     defineCommandWithArgs({
       name: `mode:${mode.toLowerCase()}`,
+      aliases: [`model:${mode.toLowerCase()}`],
       handler: (params, args) => {
         const trimmedArgs = args.trim()
 

--- a/cli/src/data/slash-commands.ts
+++ b/cli/src/data/slash-commands.ts
@@ -29,6 +29,7 @@ const MODE_COMMANDS: SlashCommand[] = IS_FREEBUFF
       id: `mode:${mode.toLowerCase()}`,
       label: `mode:${mode.toLowerCase()}`,
       description: `Switch to ${mode} mode`,
+      aliases: [`model:${mode.toLowerCase()}`],
     }))
 
 const FREEBUFF_REMOVED_COMMAND_IDS = new Set([


### PR DESCRIPTION
Adds model:<mode> aliases to the existing mode:<mode> slash commands so typing /model surfaces the mode switcher options and manually entered /model:* commands execute the same handlers. This fixes the case where model-named skills could obscure the intended model/mode switch flow. Tests cover alias lookup and slash-command metadata mapping. Validated with bun test cli/src/commands/__tests__/router-input.test.ts cli/src/commands/__tests__/command-args.test.ts.