### PR TITLE
Add Freebuff /model alias

### DIFF
--- a/cli/src/commands/__tests__/freebuff-command-aliases.test.ts
+++ b/cli/src/commands/__tests__/freebuff-command-aliases.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+describe('freebuff command aliases', () => {
+  test('/model aliases /end-session in freebuff', () => {
+    const slashCommandsUrl = new URL(
+      '../../data/slash-commands.ts',
+      import.meta.url,
+    ).href
+    const commandRegistryUrl = new URL(
+      '../command-registry.ts',
+      import.meta.url,
+    ).href
+
+    const result = Bun.spawnSync({
+      cmd: [
+        'bun',
+        '--eval',
+        `
+          import { SLASH_COMMANDS } from ${JSON.stringify(slashCommandsUrl)}
+          import { findCommand } from ${JSON.stringify(commandRegistryUrl)}
+
+          const endSession = SLASH_COMMANDS.find((cmd) => cmd.id === 'end-session')
+          if (!endSession) throw new Error('end-session slash command missing')
+          if (!endSession.aliases?.includes('model')) {
+            throw new Error('end-session slash command is missing model alias')
+          }
+
+          const modelCommand = findCommand('model')
+          if (!modelCommand) throw new Error('model command alias missing')
+          if (modelCommand.name !== 'end-session') {
+            throw new Error('model alias did not resolve to end-session')
+          }
+        `,
+      ],
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        FREEBUFF_MODE: 'true',
+        NODE_ENV: 'test',
+        NEXT_PUBLIC_CB_ENVIRONMENT: 'test',
+        NEXT_PUBLIC_CODEBUFF_APP_URL: 'https://app.codebuff.test',
+        NEXT_PUBLIC_SUPPORT_EMAIL: 'support@codebuff.test',
+        NEXT_PUBLIC_POSTHOG_API_KEY: 'phc_test_key',
+        NEXT_PUBLIC_POSTHOG_HOST_URL: 'https://posthog.codebuff.test',
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_test_123',
+        NEXT_PUBLIC_STRIPE_CUSTOMER_PORTAL: 'https://stripe.codebuff.test',
+        NEXT_PUBLIC_WEB_PORT: '3000',
+      },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    })
+
+    const stderr = new TextDecoder().decode(result.stderr)
+    expect(result.exitCode, stderr).toBe(0)
+  })
+})

--- a/cli/src/commands/command-registry.ts
+++ b/cli/src/commands/command-registry.ts
@@ -596,6 +596,7 @@ const ALL_COMMANDS: CommandDefinition[] = [
   // user picks a model and hits Enter to rejoin the queue.
   defineCommand({
     name: 'end-session',
+    aliases: ['model'],
     handler: (params) => {
       params.setMessages((prev) => [
         ...prev,

--- a/cli/src/data/slash-commands.ts
+++ b/cli/src/data/slash-commands.ts
@@ -176,7 +176,8 @@ const ALL_SLASH_COMMANDS: SlashCommand[] = [
   {
     id: 'end-session',
     label: 'end-session',
-    description: 'End your free session and return to the waiting room (lets you switch model)',
+    description: 'End your free session (lets you switch model)',
+    aliases: ['model'],
   },
   {
     id: 'logout',


### PR DESCRIPTION
Adds /model as a Freebuff-only alias for /end-session so users can return to the model picker with the shorter command. The slash menu metadata also includes the alias, so typing /model surfaces the existing end-session command instead of falling through as unknown. Adds a focused Freebuff-mode command alias test using FREEBUFF_MODE=true. Validated with bun test cli/src/commands/__tests__/freebuff-command-aliases.test.ts cli/src/commands/__tests__/router-input.test.ts.