### PR TITLE
Update Freebuff limited mode FAQ

### DIFF
--- a/freebuff/web/src/app/home-client.tsx
+++ b/freebuff/web/src/app/home-client.tsx
@@ -26,12 +26,17 @@ const faqs = [
   {
     question: 'What models do you use?',
     answer:
-      'You can choose from:\n\n- DeepSeek V4 Pro: smartest. Its API collects data for training.\n- Kimi K2.6: balanced.\n- DeepSeek V4 Flash: most efficient. Its API also collects data for training.\n- MiniMax M2.7: fastest.\n\nAlso, Gemini 3.1 Flash Lite handles file finding and research. Connect your ChatGPT subscription to unlock GPT-5.4 for deep thinking.',
+      'In full mode, you can choose from:\n\n- DeepSeek V4 Pro: smartest. Its API collects data for training.\n- Kimi K2.6: balanced.\n- DeepSeek V4 Flash: most efficient. Its API also collects data for training.\n- MiniMax M2.7: fastest.\n\nLimited mode uses DeepSeek V4 Flash only.\n\nAlso, Gemini 3.1 Flash Lite handles file finding and research. Connect your ChatGPT subscription to unlock GPT-5.4 for deep thinking.',
   },
   {
     question: 'Which countries is Freebuff available in?',
     answer:
-      'Freebuff is currently available in:\n\nUnited States, Canada, United Kingdom, Australia, New Zealand, Norway, Sweden, Netherlands, Denmark, Germany, France, Italy, Spain, Portugal, Finland, Belgium, Luxembourg, Liechtenstein, Switzerland, Austria, Singapore, Malta, Israel, Ireland, and Iceland.',
+      'Full Freebuff access is currently available in:\n\nUnited States, Canada, United Kingdom, Australia, New Zealand, Norway, Sweden, Netherlands, Denmark, Germany, France, Italy, Spain, Portugal, Finland, Belgium, Luxembourg, Liechtenstein, Switzerland, Austria, Singapore, Malta, Israel, Ireland, and Iceland.\n\nIf you are outside those countries or using a VPN, Freebuff still works in limited mode.',
+  },
+  {
+    question: 'What is limited mode?',
+    answer:
+      'Limited mode lets you use Freebuff outside the full-access countries, or while using a VPN. It includes DeepSeek V4 Flash only, with 5 one-hour sessions per day.',
   },
   {
     question: 'Are you training on my data?',


### PR DESCRIPTION
## Summary
Update the Freebuff website FAQ to explain full-country access versus limited mode. The copy now says users outside the listed countries or on VPN can still use limited mode with DeepSeek V4 Flash only, for 5 one-hour sessions per day.

## Validation
- bun --cwd freebuff/web typecheck