### PR TITLE
Undo Windows Bun baseline target

### DIFF
--- a/.github/actions/setup-bun-compile-runtime/action.yml
+++ b/.github/actions/setup-bun-compile-runtime/action.yml
@@ -3,7 +3,7 @@ description: 'Download and cache a Bun runtime used by bun build --compile-execu
 
 inputs:
   target:
-    description: 'Bun compile target, for example bun-windows-x64-baseline'
+    description: 'Bun compile target, for example bun-windows-x64'
     required: true
 
 runs:

--- a/.github/workflows/cli-release-build.yml
+++ b/.github/workflows/cli-release-build.yml
@@ -315,10 +315,10 @@ jobs:
             echo "$ENV_OVERRIDES" | jq -r 'to_entries | .[] | .key + "=" + .value' >> $GITHUB_ENV
           fi
 
-      - name: Prepare Windows baseline Bun compile runtime
+      - name: Prepare Windows Bun compile runtime
         uses: ./.github/actions/setup-bun-compile-runtime
         with:
-          target: bun-windows-x64-baseline
+          target: bun-windows-x64
 
       - name: Build binary
         run: bun run scripts/build-binary.ts ${{ inputs.binary-name }} ${{ inputs.new-version }}
@@ -326,7 +326,7 @@ jobs:
         shell: bash
         env:
           VERBOSE: true
-          OVERRIDE_TARGET: bun-windows-x64-baseline
+          OVERRIDE_TARGET: bun-windows-x64
           OVERRIDE_PLATFORM: win32
           OVERRIDE_ARCH: x64
 

--- a/.github/workflows/freebuff-e2e.yml
+++ b/.github/workflows/freebuff-e2e.yml
@@ -162,10 +162,10 @@ jobs:
           echo "NEXT_PUBLIC_CB_ENVIRONMENT=prod" >> $GITHUB_ENV
           echo "CODEBUFF_GITHUB_ACTIONS=true" >> $GITHUB_ENV
 
-      - name: Prepare Windows baseline Bun compile runtime
+      - name: Prepare Windows Bun compile runtime
         uses: ./.github/actions/setup-bun-compile-runtime
         with:
-          target: bun-windows-x64-baseline
+          target: bun-windows-x64
 
       - name: Build Freebuff binary
         run: bun freebuff/cli/build.ts 0.0.0-e2e

--- a/.github/workflows/npm-app-release-build.yml
+++ b/.github/workflows/npm-app-release-build.yml
@@ -53,7 +53,7 @@ jobs:
             arch: arm64
           - os: windows-latest
             target: win32-x64
-            bun_target: bun-windows-x64-baseline
+            bun_target: bun-windows-x64
             platform: win32
             arch: x64
     runs-on: ${{ matrix.os }}

--- a/cli/scripts/build-binary.ts
+++ b/cli/scripts/build-binary.ts
@@ -97,7 +97,7 @@ function getTargetInfo(): TargetInfo {
       arch: 'arm64',
     },
     'win32-x64': {
-      bunTarget: 'bun-windows-x64-baseline',
+      bunTarget: 'bun-windows-x64',
       platform: 'win32',
       arch: 'x64',
     },


### PR DESCRIPTION
Reverts Windows CLI and release builds from `bun-windows-x64-baseline` back to `bun-windows-x64`.

This avoids relying on the baseline runtime while it may be buggy, while keeping the existing compile-runtime setup pointed at the standard Windows target.

Validation: `git diff --check` passed, and the PR diff was reviewed with `git diff origin/main...`.