### PR TITLE
fix: respect http_proxy env vars in CLI API client

### DIFF
--- a/cli/src/utils/codebuff-api.ts
+++ b/cli/src/utils/codebuff-api.ts
@@ -103,6 +103,13 @@ export interface CodebuffApiClientConfig {
   defaultTimeoutMs?: number
   /** Default retry configuration */
   retry?: RetryConfig
+  /**
+   * Proxy URL to use for all requests.
+   * If not set, falls back to HTTPS_PROXY / https_proxy / HTTP_PROXY / http_proxy
+   * environment variables. Set to null to explicitly disable proxy even if env
+   * vars are present.
+   */
+  proxy?: string | null
 }
 
 /**
@@ -196,6 +203,23 @@ export interface CodebuffApiClient {
 }
 
 /**
+ * Resolve the proxy URL from standard environment variables.
+ * Priority: HTTPS_PROXY > https_proxy > HTTP_PROXY > http_proxy
+ * Returns undefined when no proxy is configured.
+ */
+export function resolveProxyUrl(
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  return (
+    env['HTTPS_PROXY'] ||
+    env['https_proxy'] ||
+    env['HTTP_PROXY'] ||
+    env['http_proxy'] ||
+    undefined
+  )
+}
+
+/**
  * Sleep for a given duration
  */
 const sleep = (ms: number): Promise<void> =>
@@ -253,7 +277,15 @@ export function createCodebuffApiClient(
     fetch: fetchFn = fetch,
     defaultTimeoutMs = 30000,
     retry: defaultRetryConfig = {},
+    proxy: proxyConfig,
   } = config
+
+  // Resolve proxy: explicit config wins, then env vars, then no proxy.
+  // Pass proxy: null to explicitly disable even when env vars are set.
+  const proxyUrl: string | undefined =
+    proxyConfig === null
+      ? undefined
+      : (proxyConfig ?? resolveProxyUrl())
 
   const mergedDefaultRetry: Required<RetryConfig> = {
     ...DEFAULT_RETRY_CONFIG,
@@ -321,7 +353,12 @@ export function createCodebuffApiClient(
         const response = await fetchFn(url, {
           ...fetchOptions,
           signal: controller.signal,
-        })
+          // Bun supports a `proxy` option on fetch. When a proxy URL is
+          // resolved (from config or env vars) we pass it here so that all
+          // API calls are tunnelled through the proxy. The cast is required
+          // because the WhatWG RequestInit type does not include `proxy`.
+          ...(proxyUrl ? { proxy: proxyUrl } : {}),
+        } as RequestInit)
 
         clearTimeout(timeoutId)
 


### PR DESCRIPTION
Bun's native fetch does not automatically honour HTTPS_PROXY / http_proxy environment variables unlike Node's http/https modules. Read proxy settings from standard env vars and pass them via Bun's fetch  option so corporate proxy users can route CLI traffic.