### PR TITLE
Fix read_files normalized path results

### DIFF
--- a/common/src/tools/params/tool/read-files.ts
+++ b/common/src/tools/params/tool/read-files.ts
@@ -28,7 +28,7 @@ const inputSchema = z
             .string()
             .min(1, 'Paths cannot be empty')
             .describe(
-              `File path to read relative to the **project root**. Absolute file paths will not work.`,
+              `File path to read. Prefer paths relative to the **project root**; absolute paths inside the project are accepted, but paths outside the project will not work.`,
             ),
         ),
       )

--- a/packages/agent-runtime/src/__tests__/get-file-reading-updates.test.ts
+++ b/packages/agent-runtime/src/__tests__/get-file-reading-updates.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getFileReadingUpdates } from '../get-file-reading-updates'
+
+describe('getFileReadingUpdates', () => {
+  test('returns files keyed by the requested paths', async () => {
+    const files = await getFileReadingUpdates({
+      requestedFiles: ['src/index.ts'],
+      requestFiles: async () => ({
+        'src/index.ts': 'console.log("hello")',
+      }),
+    })
+
+    expect(files).toEqual([
+      {
+        path: 'src/index.ts',
+        content: 'console.log("hello")',
+      },
+    ])
+  })
+
+  test('keeps files returned under normalized paths', async () => {
+    const files = await getFileReadingUpdates({
+      requestedFiles: ['/project/src/index.ts', './src/util.ts'],
+      requestFiles: async () => ({
+        'src/index.ts': 'console.log("hello")',
+        'src/util.ts': 'export const util = true',
+      }),
+    })
+
+    expect(files).toEqual([
+      {
+        path: 'src/index.ts',
+        content: 'console.log("hello")',
+      },
+      {
+        path: 'src/util.ts',
+        content: 'export const util = true',
+      },
+    ])
+  })
+
+  test('omits null file results', async () => {
+    const files = await getFileReadingUpdates({
+      requestedFiles: ['missing.ts', 'src/index.ts'],
+      requestFiles: async () => ({
+        'missing.ts': null,
+        'src/index.ts': 'content',
+      }),
+    })
+
+    expect(files).toEqual([
+      {
+        path: 'src/index.ts',
+        content: 'content',
+      },
+    ])
+  })
+})

--- a/packages/agent-runtime/src/get-file-reading-updates.ts
+++ b/packages/agent-runtime/src/get-file-reading-updates.ts
@@ -16,13 +16,11 @@ export async function getFileReadingUpdates(params: {
   const allFilePaths = uniq(requestedFiles)
   const loadedFiles = await requestFiles({ filePaths: allFilePaths })
 
-  const addedFiles = allFilePaths
-    .filter(
-      (path) => loadedFiles[path] != null && loadedFiles[path] !== undefined,
-    )
-    .map((path) => ({
+  const addedFiles = Object.entries(loadedFiles)
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    .map(([path, content]) => ({
       path,
-      content: loadedFiles[path]!,
+      content,
     }))
 
   return addedFiles


### PR DESCRIPTION
Fixes read_files results getting dropped when the SDK normalizes absolute or ./ paths to project-relative keys. The runtime now consumes the returned file map keys directly, while still filtering missing file results. The read_files schema description now reflects that in-project absolute paths are accepted, and a regression test covers normalized returned paths.\n\nValidation: bun test sdk/src/__tests__/read-files.test.ts packages/agent-runtime/src/__tests__/get-file-reading-updates.test.ts; bun run typecheck in packages/agent-runtime.