### PR TITLE
[codex] Handle missing CLI auth code tokens

### DIFF
--- a/freebuff/web/src/app/onboard/page.tsx
+++ b/freebuff/web/src/app/onboard/page.tsx
@@ -126,6 +126,27 @@ const Onboard = async ({ searchParams }: PageProps) => {
     )
   }
 
+  if (authCodeResolution.status === 'missing') {
+    logger.info(
+      {
+        authCodeLength: authCode.length,
+        authCodeTrimmedLength: authCode.trim().length,
+        authCodeHashPrefix: getCliAuthCodeHashPrefix(authCode),
+        isOpaqueAuthCodeToken: isOpaqueCliAuthCodeToken(authCode),
+        userId: user.id,
+      },
+      'Missing Freebuff CLI auth code token',
+    )
+
+    return (
+      <StatusCard
+        title="Login link expired"
+        description="This browser login link is no longer active."
+        message="Return to your terminal and restart Freebuff to generate a new login link."
+      />
+    )
+  }
+
   const {
     authCode: resolvedAuthCode,
     resolvedOpaqueToken,

--- a/web/src/app/onboard/page.tsx
+++ b/web/src/app/onboard/page.tsx
@@ -69,6 +69,16 @@ const Onboard = async ({ searchParams }: PageProps) => {
     )
   }
 
+  if (authCodeResolution.status === 'missing') {
+    return (
+      <CardWithBeams
+        title="This login link has expired"
+        description="Return to your terminal and restart Codebuff to generate a new login link."
+        content={<p>You can close this browser window.</p>}
+      />
+    )
+  }
+
   const { authCode: resolvedAuthCode } = authCodeResolution
   const { fingerprintId, expiresAt, receivedHash } =
     parseAuthCode(resolvedAuthCode)


### PR DESCRIPTION
## Summary

Missing opaque CLI login tokens now stop before signed auth-code validation and render a stale-link response instead of the generic invalid-auth-code path.

## Why

Freebuff occasionally logs `Invalid Freebuff CLI auth code` for 43-character opaque login tokens whose token lookup returns `missing`. Those tokens are not signed auth-code payloads, so parsing them as signed codes produces empty fields and a misleading warning/user message.

## Changes

- Add an explicit `missing` auth-code resolution branch in Freebuff onboarding.
- Log missing Freebuff opaque tokens at `info` for correlation without treating them as invalid signed codes.
- Add matching stale-link handling to the Codebuff onboarding page.

## Validation

- `bun --cwd freebuff/web typecheck`
- `bun --cwd web typecheck`
- `bunx prettier --write freebuff/web/src/app/onboard/page.tsx web/src/app/onboard/page.tsx`
- `git diff --check`