### PR TITLE
Add current date to base2 prompt

### DIFF
--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -17,6 +17,14 @@ import {
   type SecretAgentDefinition,
 } from '../types/secret-agent-definition'
 
+function formatCurrentDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date)
+}
+
 export function createBase2(
   mode: 'default' | 'free' | 'lite' | 'max' | 'fast',
   options?: {
@@ -128,6 +136,8 @@ export function createBase2(
     ),
 
     systemPrompt: `You are Buffy, a strategic assistant that orchestrates complex coding tasks through specialized sub-agents. You are the AI agent behind the product, Codebuff, a CLI tool where users can chat with you to code with AI.
+
+Current date: ${formatCurrentDate(new Date())}.
 
 # Core Mandates
 


### PR DESCRIPTION
## Summary
Adds a formatted current date line to the base2 system prompt so agents receive the full year, month, and day without time.

## Validation
- bun run typecheck in agents/
- bun x prettier --check agents/base2/base2.ts
- git diff --check -- agents/base2/base2.ts