### PR TITLE
Reduce Freebuff VPN false positives with Spur

### DIFF
--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -17,6 +17,14 @@ import {
   type SecretAgentDefinition,
 } from '../types/secret-agent-definition'
 
+function formatCurrentDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date)
+}
+
 export function createBase2(
   mode: 'default' | 'free' | 'lite' | 'max' | 'fast',
   options?: {
@@ -128,6 +136,8 @@ export function createBase2(
     ),
 
     systemPrompt: `You are Buffy, a strategic assistant that orchestrates complex coding tasks through specialized sub-agents. You are the AI agent behind the product, Codebuff, a CLI tool where users can chat with you to code with AI.
+
+Current date: ${formatCurrentDate(new Date())}.
 
 # Core Mandates
 

--- a/common/src/types/freebuff-session.ts
+++ b/common/src/types/freebuff-session.ts
@@ -65,6 +65,31 @@ export type FreebuffIpPrivacySignal =
   | 'hosting'
   | 'service'
 
+export type FreebuffSpurStatus =
+  | 'not_checked'
+  | 'clean'
+  | 'suspicious'
+  | 'failed'
+
+export type FreebuffPrivacyDecision =
+  | 'allowed_clean'
+  | 'ipinfo_suspicious_spur_clean'
+  | 'corroborated_block'
+  | 'cloudflare_tor_block'
+  | 'spur_failed_limited'
+  | 'ipinfo_failed_limited'
+  | 'limited_other'
+
+export type FreebuffPrivacyProviderDecision =
+  | 'not_checked'
+  | 'cloudflare_tor'
+  | 'ipinfo_clean'
+  | 'ipinfo_failed'
+  | 'ipinfo_only'
+  | 'spur_failed'
+  | 'corroborated_soft'
+  | 'corroborated_hard'
+
 export interface FreebuffLimitedModeReason {
   /** Present for limited access so the model picker can explain why the
    *  reduced model set is shown without re-running geo/IP logic locally. */

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -6,6 +6,7 @@
 - Server secrets: validated in `packages/internal/src/env-schema.ts` (used via `@codebuff/internal/env`).
 - Runtime/OS env: pass typed snapshots instead of reading `process.env` throughout the codebase.
 - `IPINFO_TOKEN` is required; free-mode country gating uses it to check IPinfo privacy signals for VPN/proxy/Tor/relay/hosting traffic.
+- `SPUR_TOKEN` is required; hard VPN/proxy/Tor/residential-proxy free-mode blocks require Spur Context API corroboration. In allowlisted countries, a successful clean Spur result overrides IPinfo privacy signals back to full access, while a Spur lookup failure falls back to limited access.
 - `CODEBUFF_FULL_TELEMETRY=true` or `CODEBUFF_FULL_TELEMETRY_IDS=user-id,email@example.com`
   disables client analytics sampling for targeted debugging. Use sparingly because it can send full CLI log payloads.
 

--- a/docs/freebuff-waiting-room.md
+++ b/docs/freebuff-waiting-room.md
@@ -181,7 +181,7 @@ All endpoints authenticate via the standard `Authorization: Bearer <api-key>` or
 - Existing active+unexpired row, **different model** → reject with `model_locked` (HTTP 409); `active_instance_id` is **not** rotated so the other CLI stays valid. Client must DELETE the session before switching.
 - Existing active+expired row → reset to queued with fresh `queued_at` and the requested `model` (re-queue at back).
 
-Before any of those state transitions, the handler requires a resolved allowlisted country and a successful IPinfo privacy check. IPinfo `anonymous`, `vpn`, `proxy`, `tor`, `relay`, `res_proxy`, `hosting`, and `service` signals are blocked; privacy lookup failures fail closed.
+Before any of those state transitions, the handler requires a resolved country and successful IPinfo/Spur privacy checks. Unsupported countries enter limited Freebuff access. In allowlisted countries, IPinfo privacy signals still receive full access when Spur returns clean context, fall back to limited access when Spur lookup fails, and hard-block only when Spur corroborates VPN/proxy/Tor/residential-proxy traffic. IPinfo lookup failures fail closed into limited access.
 
 Response shapes:
 

--- a/packages/internal/src/db/migrations/0053_solid_karnak.sql
+++ b/packages/internal/src/db/migrations/0053_solid_karnak.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "free_mode_country_access_cache" ADD COLUMN "spur_ip_privacy_signals" text[];--> statement-breakpoint
+ALTER TABLE "free_mode_country_access_cache" ADD COLUMN "spur_status" text;

--- a/packages/internal/src/db/migrations/0054_clumsy_robin_chapel.sql
+++ b/packages/internal/src/db/migrations/0054_clumsy_robin_chapel.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "free_mode_country_access_cache" ADD COLUMN "privacy_decision" text;--> statement-breakpoint
+ALTER TABLE "free_mode_country_access_cache" ADD COLUMN "privacy_provider_decision" text;

--- a/packages/internal/src/db/migrations/meta/0053_snapshot.json
+++ b/packages/internal/src/db/migrations/meta/0053_snapshot.json
@@ -1,0 +1,3546 @@
+{
+  "id": "bc4c1d53-8869-4bd3-b3f4-9e4262d6e4f7",
+  "prevId": "7740c15d-089b-41b6-942e-c6b9d3617c6a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_impression": {
+      "name": "ad_impression",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gravity'"
+        },
+        "ad_text": {
+          "name": "ad_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cta": {
+          "name": "cta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "click_url": {
+          "name": "click_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imp_url": {
+          "name": "imp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pixels": {
+          "name": "extra_pixels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payout": {
+          "name": "payout",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_granted": {
+          "name": "credits_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_operation_id": {
+          "name": "grant_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "served_at": {
+          "name": "served_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "impression_fired_at": {
+          "name": "impression_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ad_impression_user": {
+          "name": "idx_ad_impression_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "served_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_impression_imp_url": {
+          "name": "idx_ad_impression_imp_url",
+          "columns": [
+            {
+              "expression": "imp_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_impression_user_id_user_id_fk": {
+          "name": "ad_impression_user_id_user_id_fk",
+          "tableFrom": "ad_impression",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ad_impression_imp_url_unique": {
+          "name": "ad_impression_imp_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "imp_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config": {
+      "name": "agent_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CAST(SPLIT_PART(\"agent_config\".\"version\", '.', 1) AS INTEGER)",
+            "type": "stored"
+          }
+        },
+        "minor": {
+          "name": "minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CAST(SPLIT_PART(\"agent_config\".\"version\", '.', 2) AS INTEGER)",
+            "type": "stored"
+          }
+        },
+        "patch": {
+          "name": "patch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CAST(SPLIT_PART(\"agent_config\".\"version\", '.', 3) AS INTEGER)",
+            "type": "stored"
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_config_publisher": {
+          "name": "idx_agent_config_publisher",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_publisher_id_publisher_id_fk": {
+          "name": "agent_config_publisher_id_publisher_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "publisher",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_config_publisher_id_id_version_pk": {
+          "name": "agent_config_publisher_id_id_version_pk",
+          "columns": [
+            "publisher_id",
+            "id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE\n             WHEN agent_id ~ '^[^/@]+/[^/@]+@[^/@]+$'\n               THEN split_part(agent_id, '/', 1)\n             ELSE NULL\n           END",
+            "type": "stored"
+          }
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE\n             WHEN agent_id ~ '^[^/@]+/[^/@]+@[^/@]+$'\n               THEN split_part(split_part(agent_id, '/', 2), '@', 1)\n             ELSE agent_id\n           END",
+            "type": "stored"
+          }
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE\n             WHEN agent_id ~ '^[^/@]+/[^/@]+@[^/@]+$'\n               THEN split_part(agent_id, '@', 2)\n             ELSE NULL\n           END",
+            "type": "stored"
+          }
+        },
+        "ancestor_run_ids": {
+          "name": "ancestor_run_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_run_id": {
+          "name": "root_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN array_length(ancestor_run_ids, 1) >= 1 THEN ancestor_run_ids[1] ELSE id END",
+            "type": "stored"
+          }
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN array_length(ancestor_run_ids, 1) >= 1 THEN ancestor_run_ids[array_length(ancestor_run_ids, 1)] ELSE NULL END",
+            "type": "stored"
+          }
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "COALESCE(array_length(ancestor_run_ids, 1), 1)",
+            "type": "stored"
+          }
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN completed_at IS NOT NULL THEN EXTRACT(EPOCH FROM (completed_at - created_at)) * 1000 ELSE NULL END::integer",
+            "type": "stored"
+          }
+        },
+        "total_steps": {
+          "name": "total_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "direct_credits": {
+          "name": "direct_credits",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_credits": {
+          "name": "total_credits",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_run_user_id": {
+          "name": "idx_agent_run_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_parent": {
+          "name": "idx_agent_run_parent",
+          "columns": [
+            {
+              "expression": "parent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_root": {
+          "name": "idx_agent_run_root",
+          "columns": [
+            {
+              "expression": "root_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_agent_id": {
+          "name": "idx_agent_run_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_publisher": {
+          "name": "idx_agent_run_publisher",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_status": {
+          "name": "idx_agent_run_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_ancestors_gin": {
+          "name": "idx_agent_run_ancestors_gin",
+          "columns": [
+            {
+              "expression": "ancestor_run_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_agent_run_completed_publisher_agent": {
+          "name": "idx_agent_run_completed_publisher_agent",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_completed_recent": {
+          "name": "idx_agent_run_completed_recent",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_completed_version": {
+          "name": "idx_agent_run_completed_version",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_completed_user": {
+          "name": "idx_agent_run_completed_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_user_id_user_id_fk": {
+          "name": "agent_run_user_id_user_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_step": {
+      "name": "agent_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN completed_at IS NOT NULL THEN EXTRACT(EPOCH FROM (completed_at - created_at)) * 1000 ELSE NULL END::integer",
+            "type": "stored"
+          }
+        },
+        "credits": {
+          "name": "credits",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "child_run_ids": {
+          "name": "child_run_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spawned_count": {
+          "name": "spawned_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "array_length(child_run_ids, 1)",
+            "type": "stored"
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_step_number_per_run": {
+          "name": "unique_step_number_per_run",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_step_run_id": {
+          "name": "idx_agent_step_run_id",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_step_children_gin": {
+          "name": "idx_agent_step_children_gin",
+          "columns": [
+            {
+              "expression": "child_run_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_step_agent_run_id_agent_run_id_fk": {
+          "name": "agent_step_agent_run_id_agent_run_id_fk",
+          "tableFrom": "agent_step",
+          "tableTo": "agent_run",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "grant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_credit_ledger_active_balance": {
+          "name": "idx_credit_ledger_active_balance",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "balance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"credit_ledger\".\"balance\" != 0 AND \"credit_ledger\".\"expires_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_ledger_org": {
+          "name": "idx_credit_ledger_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_ledger_subscription": {
+          "name": "idx_credit_ledger_subscription",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_user_id_user_id_fk": {
+          "name": "credit_ledger_user_id_user_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_org_id_org_id_fk": {
+          "name": "credit_ledger_org_id_org_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encrypted_api_keys": {
+      "name": "encrypted_api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "api_key_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encrypted_api_keys_user_id_user_id_fk": {
+          "name": "encrypted_api_keys_user_id_user_id_fk",
+          "tableFrom": "encrypted_api_keys",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "encrypted_api_keys_user_id_type_pk": {
+          "name": "encrypted_api_keys_user_id_type_pk",
+          "columns": [
+            "user_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fingerprint": {
+      "name": "fingerprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sig_hash": {
+          "name": "sig_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_mode_country_access_cache": {
+      "name": "free_mode_country_access_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_ip_hash": {
+          "name": "client_ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed": {
+          "name": "allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cf_country": {
+          "name": "cf_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geoip_country": {
+          "name": "geoip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_block_reason": {
+          "name": "country_block_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_privacy_signals": {
+          "name": "ip_privacy_signals",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spur_ip_privacy_signals": {
+          "name": "spur_ip_privacy_signals",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spur_status": {
+          "name": "spur_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_free_mode_country_cache_expires_at": {
+          "name": "idx_free_mode_country_cache_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_mode_country_access_cache_user_id_user_id_fk": {
+          "name": "free_mode_country_access_cache_user_id_user_id_fk",
+          "tableFrom": "free_mode_country_access_cache",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "free_mode_country_access_cache_user_id_client_ip_hash_pk": {
+          "name": "free_mode_country_access_cache_user_id_client_ip_hash_pk",
+          "columns": [
+            "user_id",
+            "client_ip_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_session": {
+      "name": "free_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "free_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_instance_id": {
+          "name": "active_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_tier": {
+          "name": "access_tier",
+          "type": "freebuff_access_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cf_country": {
+          "name": "cf_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geoip_country": {
+          "name": "geoip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_block_reason": {
+          "name": "country_block_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_privacy_signals": {
+          "name": "ip_privacy_signals",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip_hash": {
+          "name": "client_ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_checked_at": {
+          "name": "country_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_free_session_queue": {
+          "name": "idx_free_session_queue",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_free_session_expiry": {
+          "name": "idx_free_session_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_session_user_id_user_id_fk": {
+          "name": "free_session_user_id_user_id_fk",
+          "tableFrom": "free_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_session_admit": {
+      "name": "free_session_admit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_tier": {
+          "name": "access_tier",
+          "type": "freebuff_access_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_units": {
+          "name": "session_units",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        }
+      },
+      "indexes": {
+        "idx_free_session_admit_user_model_time": {
+          "name": "idx_free_session_admit_user_model_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "admitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_session_admit_user_id_user_id_fk": {
+          "name": "free_session_admit_user_id_user_id_fk",
+          "tableFrom": "free_session_admit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_eval_results": {
+      "name": "git_eval_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cost_mode": {
+          "name": "cost_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoner_model": {
+          "name": "reasoner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_model": {
+          "name": "agent_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.limit_override": {
+      "name": "limit_override",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits_per_block": {
+          "name": "credits_per_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_duration_hours": {
+          "name": "block_duration_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_credit_limit": {
+          "name": "weekly_credit_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "limit_override_user_id_user_id_fk": {
+          "name": "limit_override_user_id_user_id_fk",
+          "tableFrom": "limit_override",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message": {
+          "name": "last_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\"message\".\"request\" -> -1",
+            "type": "stored"
+          }
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(100, 20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byok": {
+          "name": "byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "message_user_id_idx": {
+          "name": "message_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_finished_at_user_id_idx": {
+          "name": "message_finished_at_user_id_idx",
+          "columns": [
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_org_id_idx": {
+          "name": "message_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_org_id_finished_at_idx": {
+          "name": "message_org_id_finished_at_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_user_id_user_id_fk": {
+          "name": "message_user_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_org_id_org_id_fk": {
+          "name": "message_org_id_org_id_fk",
+          "tableFrom": "message",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org": {
+      "name": "org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_enabled": {
+          "name": "auto_topup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_threshold": {
+          "name": "auto_topup_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_topup_amount": {
+          "name": "auto_topup_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_limit": {
+          "name": "credit_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_alerts": {
+          "name": "billing_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekly_reports": {
+          "name": "weekly_reports",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_owner_id_user_id_fk": {
+          "name": "org_owner_id_user_id_fk",
+          "tableFrom": "org",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_slug_unique": {
+          "name": "org_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "org_stripe_customer_id_unique": {
+          "name": "org_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_feature": {
+      "name": "org_feature",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_feature_active": {
+          "name": "idx_org_feature_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_feature_org_id_org_id_fk": {
+          "name": "org_feature_org_id_org_id_fk",
+          "tableFrom": "org_feature",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_feature_org_id_feature_pk": {
+          "name": "org_feature_org_id_feature_pk",
+          "columns": [
+            "org_id",
+            "feature"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invite": {
+      "name": "org_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_org_invite_token": {
+          "name": "idx_org_invite_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invite_email": {
+          "name": "idx_org_invite_email",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invite_expires": {
+          "name": "idx_org_invite_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invite_org_id_org_id_fk": {
+          "name": "org_invite_org_id_org_id_fk",
+          "tableFrom": "org_invite",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invite_invited_by_user_id_fk": {
+          "name": "org_invite_invited_by_user_id_fk",
+          "tableFrom": "org_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_invite_accepted_by_user_id_fk": {
+          "name": "org_invite_accepted_by_user_id_fk",
+          "tableFrom": "org_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invite_token_unique": {
+          "name": "org_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_member": {
+      "name": "org_member",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_member_org_id_org_id_fk": {
+          "name": "org_member_org_id_org_id_fk",
+          "tableFrom": "org_member",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_member_user_id_user_id_fk": {
+          "name": "org_member_user_id_user_id_fk",
+          "tableFrom": "org_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_member_org_id_user_id_pk": {
+          "name": "org_member_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_repo": {
+      "name": "org_repo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_org_repo_active": {
+          "name": "idx_org_repo_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_repo_unique": {
+          "name": "idx_org_repo_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_repo_org_id_org_id_fk": {
+          "name": "org_repo_org_id_org_id_fk",
+          "tableFrom": "org_repo",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_repo_approved_by_user_id_fk": {
+          "name": "org_repo_approved_by_user_id_fk",
+          "tableFrom": "org_repo",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publisher": {
+      "name": "publisher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "publisher_user_id_user_id_fk": {
+          "name": "publisher_user_id_user_id_fk",
+          "tableFrom": "publisher",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "publisher_org_id_org_id_fk": {
+          "name": "publisher_org_id_org_id_fk",
+          "tableFrom": "publisher",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "publisher_created_by_user_id_fk": {
+          "name": "publisher_created_by_user_id_fk",
+          "tableFrom": "publisher",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "publisher_single_owner": {
+          "name": "publisher_single_owner",
+          "value": "(\"publisher\".\"user_id\" IS NOT NULL AND \"publisher\".\"org_id\" IS NULL) OR\n    (\"publisher\".\"user_id\" IS NULL AND \"publisher\".\"org_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.referral": {
+      "name": "referral",
+      "schema": "",
+      "columns": {
+        "referrer_id": {
+          "name": "referrer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referred_id": {
+          "name": "referred_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_legacy": {
+          "name": "is_legacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "referral_referrer_id_user_id_fk": {
+          "name": "referral_referrer_id_user_id_fk",
+          "tableFrom": "referral",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referrer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "referral_referred_id_user_id_fk": {
+          "name": "referral_referred_id_user_id_fk",
+          "tableFrom": "referral",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referred_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_referrer_id_referred_id_pk": {
+          "name": "referral_referrer_id_referred_id_pk",
+          "columns": [
+            "referrer_id",
+            "referred_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_id": {
+          "name": "fingerprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_auth_hash": {
+          "name": "cli_auth_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "session_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_cli_auth_code_idx": {
+          "name": "session_cli_auth_code_idx",
+          "columns": [
+            {
+              "expression": "fingerprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_auth_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session\".\"cli_auth_hash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_fingerprint_id_fingerprint_id_fk": {
+          "name": "session_fingerprint_id_fingerprint_id_fk",
+          "tableFrom": "session",
+          "tableTo": "fingerprint",
+          "columnsFrom": [
+            "fingerprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_tier": {
+          "name": "scheduled_tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "billing_period_start": {
+          "name": "billing_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_end": {
+          "name": "billing_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscription_customer": {
+          "name": "idx_subscription_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_user": {
+          "name": "idx_subscription_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_status": {
+          "name": "idx_subscription_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"subscription\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_failure": {
+      "name": "sync_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sync_failure_retry": {
+          "name": "idx_sync_failure_retry",
+          "columns": [
+            {
+              "expression": "retry_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sync_failure\".\"retry_count\" < 5",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quota_reset": {
+          "name": "next_quota_reset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now() + INTERVAL '1 month'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ref-' || gen_random_uuid()"
+        },
+        "referral_limit": {
+          "name": "referral_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_enabled": {
+          "name": "auto_topup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_threshold": {
+          "name": "auto_topup_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_amount": {
+          "name": "auto_topup_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fallback_to_a_la_carte": {
+          "name": "fallback_to_a_la_carte",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "user_referral_code_unique": {
+          "name": "user_referral_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "referral_code"
+          ]
+        },
+        "user_discord_id_unique": {
+          "name": "user_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "user_handle_unique": {
+          "name": "user_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.referral_status": {
+      "name": "referral_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    },
+    "public.agent_run_status": {
+      "name": "agent_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.agent_step_status": {
+      "name": "agent_step_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "skipped"
+      ]
+    },
+    "public.api_key_type": {
+      "name": "api_key_type",
+      "schema": "public",
+      "values": [
+        "anthropic",
+        "gemini",
+        "openai"
+      ]
+    },
+    "public.free_session_status": {
+      "name": "free_session_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "active"
+      ]
+    },
+    "public.freebuff_access_tier": {
+      "name": "freebuff_access_tier",
+      "schema": "public",
+      "values": [
+        "full",
+        "limited"
+      ]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": [
+        "free",
+        "referral",
+        "referral_legacy",
+        "subscription",
+        "purchase",
+        "admin",
+        "organization",
+        "ad"
+      ]
+    },
+    "public.org_role": {
+      "name": "org_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.session_type": {
+      "name": "session_type",
+      "schema": "public",
+      "values": [
+        "web",
+        "pat",
+        "cli"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "paused"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/internal/src/db/migrations/meta/0054_snapshot.json
+++ b/packages/internal/src/db/migrations/meta/0054_snapshot.json
@@ -1,0 +1,3558 @@
+{
+  "id": "65b385f2-68c6-4a6c-b41e-c3d781d4d9c5",
+  "prevId": "bc4c1d53-8869-4bd3-b3f4-9e4262d6e4f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_impression": {
+      "name": "ad_impression",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gravity'"
+        },
+        "ad_text": {
+          "name": "ad_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cta": {
+          "name": "cta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "click_url": {
+          "name": "click_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imp_url": {
+          "name": "imp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pixels": {
+          "name": "extra_pixels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payout": {
+          "name": "payout",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_granted": {
+          "name": "credits_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_operation_id": {
+          "name": "grant_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "served_at": {
+          "name": "served_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "impression_fired_at": {
+          "name": "impression_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ad_impression_user": {
+          "name": "idx_ad_impression_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "served_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_impression_imp_url": {
+          "name": "idx_ad_impression_imp_url",
+          "columns": [
+            {
+              "expression": "imp_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_impression_user_id_user_id_fk": {
+          "name": "ad_impression_user_id_user_id_fk",
+          "tableFrom": "ad_impression",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ad_impression_imp_url_unique": {
+          "name": "ad_impression_imp_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "imp_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config": {
+      "name": "agent_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CAST(SPLIT_PART(\"agent_config\".\"version\", '.', 1) AS INTEGER)",
+            "type": "stored"
+          }
+        },
+        "minor": {
+          "name": "minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CAST(SPLIT_PART(\"agent_config\".\"version\", '.', 2) AS INTEGER)",
+            "type": "stored"
+          }
+        },
+        "patch": {
+          "name": "patch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CAST(SPLIT_PART(\"agent_config\".\"version\", '.', 3) AS INTEGER)",
+            "type": "stored"
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_config_publisher": {
+          "name": "idx_agent_config_publisher",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_publisher_id_publisher_id_fk": {
+          "name": "agent_config_publisher_id_publisher_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "publisher",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_config_publisher_id_id_version_pk": {
+          "name": "agent_config_publisher_id_id_version_pk",
+          "columns": [
+            "publisher_id",
+            "id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE\n             WHEN agent_id ~ '^[^/@]+/[^/@]+@[^/@]+$'\n               THEN split_part(agent_id, '/', 1)\n             ELSE NULL\n           END",
+            "type": "stored"
+          }
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE\n             WHEN agent_id ~ '^[^/@]+/[^/@]+@[^/@]+$'\n               THEN split_part(split_part(agent_id, '/', 2), '@', 1)\n             ELSE agent_id\n           END",
+            "type": "stored"
+          }
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE\n             WHEN agent_id ~ '^[^/@]+/[^/@]+@[^/@]+$'\n               THEN split_part(agent_id, '@', 2)\n             ELSE NULL\n           END",
+            "type": "stored"
+          }
+        },
+        "ancestor_run_ids": {
+          "name": "ancestor_run_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_run_id": {
+          "name": "root_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN array_length(ancestor_run_ids, 1) >= 1 THEN ancestor_run_ids[1] ELSE id END",
+            "type": "stored"
+          }
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN array_length(ancestor_run_ids, 1) >= 1 THEN ancestor_run_ids[array_length(ancestor_run_ids, 1)] ELSE NULL END",
+            "type": "stored"
+          }
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "COALESCE(array_length(ancestor_run_ids, 1), 1)",
+            "type": "stored"
+          }
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN completed_at IS NOT NULL THEN EXTRACT(EPOCH FROM (completed_at - created_at)) * 1000 ELSE NULL END::integer",
+            "type": "stored"
+          }
+        },
+        "total_steps": {
+          "name": "total_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "direct_credits": {
+          "name": "direct_credits",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_credits": {
+          "name": "total_credits",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_run_user_id": {
+          "name": "idx_agent_run_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_parent": {
+          "name": "idx_agent_run_parent",
+          "columns": [
+            {
+              "expression": "parent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_root": {
+          "name": "idx_agent_run_root",
+          "columns": [
+            {
+              "expression": "root_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_agent_id": {
+          "name": "idx_agent_run_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_publisher": {
+          "name": "idx_agent_run_publisher",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_status": {
+          "name": "idx_agent_run_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_ancestors_gin": {
+          "name": "idx_agent_run_ancestors_gin",
+          "columns": [
+            {
+              "expression": "ancestor_run_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_agent_run_completed_publisher_agent": {
+          "name": "idx_agent_run_completed_publisher_agent",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_completed_recent": {
+          "name": "idx_agent_run_completed_recent",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_completed_version": {
+          "name": "idx_agent_run_completed_version",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_completed_user": {
+          "name": "idx_agent_run_completed_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_run\".\"status\" = 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_user_id_user_id_fk": {
+          "name": "agent_run_user_id_user_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_step": {
+      "name": "agent_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN completed_at IS NOT NULL THEN EXTRACT(EPOCH FROM (completed_at - created_at)) * 1000 ELSE NULL END::integer",
+            "type": "stored"
+          }
+        },
+        "credits": {
+          "name": "credits",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "child_run_ids": {
+          "name": "child_run_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spawned_count": {
+          "name": "spawned_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "array_length(child_run_ids, 1)",
+            "type": "stored"
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_step_number_per_run": {
+          "name": "unique_step_number_per_run",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_step_run_id": {
+          "name": "idx_agent_step_run_id",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_step_children_gin": {
+          "name": "idx_agent_step_children_gin",
+          "columns": [
+            {
+              "expression": "child_run_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_step_agent_run_id_agent_run_id_fk": {
+          "name": "agent_step_agent_run_id_agent_run_id_fk",
+          "tableFrom": "agent_step",
+          "tableTo": "agent_run",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "grant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_credit_ledger_active_balance": {
+          "name": "idx_credit_ledger_active_balance",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "balance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"credit_ledger\".\"balance\" != 0 AND \"credit_ledger\".\"expires_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_ledger_org": {
+          "name": "idx_credit_ledger_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_ledger_subscription": {
+          "name": "idx_credit_ledger_subscription",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_user_id_user_id_fk": {
+          "name": "credit_ledger_user_id_user_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_org_id_org_id_fk": {
+          "name": "credit_ledger_org_id_org_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encrypted_api_keys": {
+      "name": "encrypted_api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "api_key_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encrypted_api_keys_user_id_user_id_fk": {
+          "name": "encrypted_api_keys_user_id_user_id_fk",
+          "tableFrom": "encrypted_api_keys",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "encrypted_api_keys_user_id_type_pk": {
+          "name": "encrypted_api_keys_user_id_type_pk",
+          "columns": [
+            "user_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fingerprint": {
+      "name": "fingerprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sig_hash": {
+          "name": "sig_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_mode_country_access_cache": {
+      "name": "free_mode_country_access_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_ip_hash": {
+          "name": "client_ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed": {
+          "name": "allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cf_country": {
+          "name": "cf_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geoip_country": {
+          "name": "geoip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_block_reason": {
+          "name": "country_block_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_privacy_signals": {
+          "name": "ip_privacy_signals",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spur_ip_privacy_signals": {
+          "name": "spur_ip_privacy_signals",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spur_status": {
+          "name": "spur_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_decision": {
+          "name": "privacy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_provider_decision": {
+          "name": "privacy_provider_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_free_mode_country_cache_expires_at": {
+          "name": "idx_free_mode_country_cache_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_mode_country_access_cache_user_id_user_id_fk": {
+          "name": "free_mode_country_access_cache_user_id_user_id_fk",
+          "tableFrom": "free_mode_country_access_cache",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "free_mode_country_access_cache_user_id_client_ip_hash_pk": {
+          "name": "free_mode_country_access_cache_user_id_client_ip_hash_pk",
+          "columns": [
+            "user_id",
+            "client_ip_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_session": {
+      "name": "free_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "free_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_instance_id": {
+          "name": "active_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_tier": {
+          "name": "access_tier",
+          "type": "freebuff_access_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cf_country": {
+          "name": "cf_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geoip_country": {
+          "name": "geoip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_block_reason": {
+          "name": "country_block_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_privacy_signals": {
+          "name": "ip_privacy_signals",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip_hash": {
+          "name": "client_ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_checked_at": {
+          "name": "country_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_free_session_queue": {
+          "name": "idx_free_session_queue",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_free_session_expiry": {
+          "name": "idx_free_session_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_session_user_id_user_id_fk": {
+          "name": "free_session_user_id_user_id_fk",
+          "tableFrom": "free_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_session_admit": {
+      "name": "free_session_admit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_tier": {
+          "name": "access_tier",
+          "type": "freebuff_access_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_units": {
+          "name": "session_units",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        }
+      },
+      "indexes": {
+        "idx_free_session_admit_user_model_time": {
+          "name": "idx_free_session_admit_user_model_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "admitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_session_admit_user_id_user_id_fk": {
+          "name": "free_session_admit_user_id_user_id_fk",
+          "tableFrom": "free_session_admit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_eval_results": {
+      "name": "git_eval_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cost_mode": {
+          "name": "cost_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoner_model": {
+          "name": "reasoner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_model": {
+          "name": "agent_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.limit_override": {
+      "name": "limit_override",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits_per_block": {
+          "name": "credits_per_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_duration_hours": {
+          "name": "block_duration_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_credit_limit": {
+          "name": "weekly_credit_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "limit_override_user_id_user_id_fk": {
+          "name": "limit_override_user_id_user_id_fk",
+          "tableFrom": "limit_override",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message": {
+          "name": "last_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\"message\".\"request\" -> -1",
+            "type": "stored"
+          }
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(100, 20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byok": {
+          "name": "byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "message_user_id_idx": {
+          "name": "message_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_finished_at_user_id_idx": {
+          "name": "message_finished_at_user_id_idx",
+          "columns": [
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_org_id_idx": {
+          "name": "message_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_org_id_finished_at_idx": {
+          "name": "message_org_id_finished_at_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_user_id_user_id_fk": {
+          "name": "message_user_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_org_id_org_id_fk": {
+          "name": "message_org_id_org_id_fk",
+          "tableFrom": "message",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org": {
+      "name": "org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_enabled": {
+          "name": "auto_topup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_threshold": {
+          "name": "auto_topup_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_topup_amount": {
+          "name": "auto_topup_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_limit": {
+          "name": "credit_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_alerts": {
+          "name": "billing_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekly_reports": {
+          "name": "weekly_reports",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_owner_id_user_id_fk": {
+          "name": "org_owner_id_user_id_fk",
+          "tableFrom": "org",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_slug_unique": {
+          "name": "org_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "org_stripe_customer_id_unique": {
+          "name": "org_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_feature": {
+      "name": "org_feature",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_feature_active": {
+          "name": "idx_org_feature_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_feature_org_id_org_id_fk": {
+          "name": "org_feature_org_id_org_id_fk",
+          "tableFrom": "org_feature",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_feature_org_id_feature_pk": {
+          "name": "org_feature_org_id_feature_pk",
+          "columns": [
+            "org_id",
+            "feature"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invite": {
+      "name": "org_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_org_invite_token": {
+          "name": "idx_org_invite_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invite_email": {
+          "name": "idx_org_invite_email",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invite_expires": {
+          "name": "idx_org_invite_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invite_org_id_org_id_fk": {
+          "name": "org_invite_org_id_org_id_fk",
+          "tableFrom": "org_invite",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invite_invited_by_user_id_fk": {
+          "name": "org_invite_invited_by_user_id_fk",
+          "tableFrom": "org_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_invite_accepted_by_user_id_fk": {
+          "name": "org_invite_accepted_by_user_id_fk",
+          "tableFrom": "org_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invite_token_unique": {
+          "name": "org_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_member": {
+      "name": "org_member",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_member_org_id_org_id_fk": {
+          "name": "org_member_org_id_org_id_fk",
+          "tableFrom": "org_member",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_member_user_id_user_id_fk": {
+          "name": "org_member_user_id_user_id_fk",
+          "tableFrom": "org_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_member_org_id_user_id_pk": {
+          "name": "org_member_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_repo": {
+      "name": "org_repo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_org_repo_active": {
+          "name": "idx_org_repo_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_repo_unique": {
+          "name": "idx_org_repo_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_repo_org_id_org_id_fk": {
+          "name": "org_repo_org_id_org_id_fk",
+          "tableFrom": "org_repo",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_repo_approved_by_user_id_fk": {
+          "name": "org_repo_approved_by_user_id_fk",
+          "tableFrom": "org_repo",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publisher": {
+      "name": "publisher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "publisher_user_id_user_id_fk": {
+          "name": "publisher_user_id_user_id_fk",
+          "tableFrom": "publisher",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "publisher_org_id_org_id_fk": {
+          "name": "publisher_org_id_org_id_fk",
+          "tableFrom": "publisher",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "publisher_created_by_user_id_fk": {
+          "name": "publisher_created_by_user_id_fk",
+          "tableFrom": "publisher",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "publisher_single_owner": {
+          "name": "publisher_single_owner",
+          "value": "(\"publisher\".\"user_id\" IS NOT NULL AND \"publisher\".\"org_id\" IS NULL) OR\n    (\"publisher\".\"user_id\" IS NULL AND \"publisher\".\"org_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.referral": {
+      "name": "referral",
+      "schema": "",
+      "columns": {
+        "referrer_id": {
+          "name": "referrer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referred_id": {
+          "name": "referred_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_legacy": {
+          "name": "is_legacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "referral_referrer_id_user_id_fk": {
+          "name": "referral_referrer_id_user_id_fk",
+          "tableFrom": "referral",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referrer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "referral_referred_id_user_id_fk": {
+          "name": "referral_referred_id_user_id_fk",
+          "tableFrom": "referral",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referred_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_referrer_id_referred_id_pk": {
+          "name": "referral_referrer_id_referred_id_pk",
+          "columns": [
+            "referrer_id",
+            "referred_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_id": {
+          "name": "fingerprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_auth_hash": {
+          "name": "cli_auth_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "session_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_cli_auth_code_idx": {
+          "name": "session_cli_auth_code_idx",
+          "columns": [
+            {
+              "expression": "fingerprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_auth_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session\".\"cli_auth_hash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_fingerprint_id_fingerprint_id_fk": {
+          "name": "session_fingerprint_id_fingerprint_id_fk",
+          "tableFrom": "session",
+          "tableTo": "fingerprint",
+          "columnsFrom": [
+            "fingerprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_tier": {
+          "name": "scheduled_tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "billing_period_start": {
+          "name": "billing_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_end": {
+          "name": "billing_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscription_customer": {
+          "name": "idx_subscription_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_user": {
+          "name": "idx_subscription_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_status": {
+          "name": "idx_subscription_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"subscription\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_failure": {
+      "name": "sync_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sync_failure_retry": {
+          "name": "idx_sync_failure_retry",
+          "columns": [
+            {
+              "expression": "retry_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sync_failure\".\"retry_count\" < 5",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quota_reset": {
+          "name": "next_quota_reset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now() + INTERVAL '1 month'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ref-' || gen_random_uuid()"
+        },
+        "referral_limit": {
+          "name": "referral_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_enabled": {
+          "name": "auto_topup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_threshold": {
+          "name": "auto_topup_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_amount": {
+          "name": "auto_topup_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fallback_to_a_la_carte": {
+          "name": "fallback_to_a_la_carte",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "user_referral_code_unique": {
+          "name": "user_referral_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "referral_code"
+          ]
+        },
+        "user_discord_id_unique": {
+          "name": "user_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "user_handle_unique": {
+          "name": "user_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.referral_status": {
+      "name": "referral_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    },
+    "public.agent_run_status": {
+      "name": "agent_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.agent_step_status": {
+      "name": "agent_step_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "skipped"
+      ]
+    },
+    "public.api_key_type": {
+      "name": "api_key_type",
+      "schema": "public",
+      "values": [
+        "anthropic",
+        "gemini",
+        "openai"
+      ]
+    },
+    "public.free_session_status": {
+      "name": "free_session_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "active"
+      ]
+    },
+    "public.freebuff_access_tier": {
+      "name": "freebuff_access_tier",
+      "schema": "public",
+      "values": [
+        "full",
+        "limited"
+      ]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": [
+        "free",
+        "referral",
+        "referral_legacy",
+        "subscription",
+        "purchase",
+        "admin",
+        "organization",
+        "ad"
+      ]
+    },
+    "public.org_role": {
+      "name": "org_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.session_type": {
+      "name": "session_type",
+      "schema": "public",
+      "values": [
+        "web",
+        "pat",
+        "cli"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "paused"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/internal/src/db/migrations/meta/_journal.json
+++ b/packages/internal/src/db/migrations/meta/_journal.json
@@ -372,6 +372,20 @@
       "when": 1778617513407,
       "tag": "0052_black_fantastic_four",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1779337734037,
+      "tag": "0053_solid_karnak",
+      "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1779339183837,
+      "tag": "0054_clumsy_robin_chapel",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/internal/src/db/schema.ts
+++ b/packages/internal/src/db/schema.ts
@@ -22,6 +22,9 @@ import type { AdapterAccount } from 'next-auth/adapters'
 import type {
   FreebuffCountryBlockReason,
   FreebuffIpPrivacySignal,
+  FreebuffPrivacyDecision,
+  FreebuffPrivacyProviderDecision,
+  FreebuffSpurStatus,
 } from '@codebuff/common/types/freebuff-session'
 
 export const ReferralStatus = pgEnum('referral_status', [
@@ -937,6 +940,16 @@ export const freeModeCountryAccessCache = pgTable(
     ip_privacy_signals: text('ip_privacy_signals')
       .array()
       .$type<FreebuffIpPrivacySignal[] | null>(),
+    spur_ip_privacy_signals: text('spur_ip_privacy_signals')
+      .array()
+      .$type<FreebuffIpPrivacySignal[] | null>(),
+    spur_status: text('spur_status').$type<FreebuffSpurStatus | null>(),
+    privacy_decision: text('privacy_decision').$type<
+      FreebuffPrivacyDecision | null
+    >(),
+    privacy_provider_decision: text('privacy_provider_decision').$type<
+      FreebuffPrivacyProviderDecision | null
+    >(),
     checked_at: timestamp('checked_at', {
       mode: 'date',
       withTimezone: true,

--- a/packages/internal/src/env-schema.ts
+++ b/packages/internal/src/env-schema.ts
@@ -16,6 +16,7 @@ export const serverEnvSchema = clientEnvSchema.extend({
   CONTEXT7_API_KEY: z.string().optional(),
   GRAVITY_API_KEY: z.string().min(1),
   IPINFO_TOKEN: z.string().min(1),
+  SPUR_TOKEN: z.string().min(1),
   // ZeroClick tenant API key used for server-side offer fallback requests.
   ZEROCLICK_API_KEY: z.string().min(1).optional(),
   // BuySellAds (Carbon) zone key used for the Freebuff waiting-room ad.
@@ -108,6 +109,7 @@ export const serverProcessEnv: ServerInput = {
   CONTEXT7_API_KEY: process.env.CONTEXT7_API_KEY,
   GRAVITY_API_KEY: process.env.GRAVITY_API_KEY,
   IPINFO_TOKEN: process.env.IPINFO_TOKEN,
+  SPUR_TOKEN: process.env.SPUR_TOKEN,
   ZEROCLICK_API_KEY: process.env.ZEROCLICK_API_KEY,
   CARBON_ZONE_KEY: process.env.CARBON_ZONE_KEY,
   PORT: process.env.PORT,

--- a/packages/internal/src/env.ts
+++ b/packages/internal/src/env.ts
@@ -24,6 +24,7 @@ if (isCI) {
   ensureEnvDefault('LINKUP_API_KEY', 'test')
   ensureEnvDefault('GRAVITY_API_KEY', 'test')
   ensureEnvDefault('IPINFO_TOKEN', 'test')
+  ensureEnvDefault('SPUR_TOKEN', 'test')
   ensureEnvDefault('PORT', '4242')
   ensureEnvDefault('DATABASE_URL', 'postgres://user:pass@localhost:5432/db')
   ensureEnvDefault('CODEBUFF_GITHUB_ID', 'test-id')

--- a/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
+++ b/web/src/app/api/v1/chat/completions/__tests__/completions.test.ts
@@ -670,6 +670,8 @@ describe('/api/v1/chat/completions POST endpoint', () => {
             cfCountry: 'US',
             geoipCountry: null,
             ipPrivacy: { signals: ['vpn', 'hosting'] },
+            spurIpPrivacy: { signals: ['vpn'] },
+            spurStatus: 'suspicious',
             hasClientIp: true,
             clientIpHash: 'test-ip-hash',
           }),
@@ -701,6 +703,10 @@ describe('/api/v1/chat/completions POST endpoint', () => {
           accessStatus: 'blocked',
           countryCode: 'US',
           ipPrivacySignals: ['vpn', 'hosting'],
+          spurStatus: 'suspicious',
+          privacyDecision: 'corroborated_block',
+          privacyProviderDecision: 'corroborated_hard',
+          privacyHardBlocked: true,
         })
         expect(validationEvent?.properties).not.toHaveProperty('accessTier')
       },
@@ -747,9 +753,7 @@ describe('/api/v1/chat/completions POST endpoint', () => {
 
           const trackedEvents = (
             mockTrackEvent as ReturnType<typeof mock>
-          ).mock.calls.map(
-            ([params]) => params as Parameters<TrackEventFn>[0],
-          )
+          ).mock.calls.map(([params]) => params as Parameters<TrackEventFn>[0])
           const requestEvent = trackedEvents.find(
             ({ event }) => event === AnalyticsEvent.CHAT_COMPLETIONS_REQUEST,
           )
@@ -761,10 +765,18 @@ describe('/api/v1/chat/completions POST endpoint', () => {
           expect(requestEvent?.properties).toMatchObject({
             freebuff: true,
             accessTier: 'full',
+            privacyDecision: 'allowed_clean',
+            privacyProviderDecision: 'ipinfo_clean',
+            privacyHardBlocked: false,
+            spurStatus: 'not_checked',
           })
           expect(generationEvent?.properties).toMatchObject({
             freebuff: true,
             accessTier: 'full',
+            privacyDecision: 'allowed_clean',
+            privacyProviderDecision: 'ipinfo_clean',
+            privacyHardBlocked: false,
+            spurStatus: 'not_checked',
           })
         } finally {
           Math.random = originalRandom

--- a/web/src/app/api/v1/chat/completions/_post.ts
+++ b/web/src/app/api/v1/chat/completions/_post.ts
@@ -103,6 +103,8 @@ import {
 import { getCachedFreeModeCountryAccess } from '@/server/free-mode-country-access-cache'
 import {
   getFreeModeAccessTier,
+  getFreeModePrivacyDecision,
+  getFreeModePrivacyProviderDecision,
   shouldHardBlockFreeModeAccess,
 } from '@/server/free-mode-country'
 
@@ -342,6 +344,7 @@ export async function postChatCompletions(params: {
       const countryAccess = await resolveCountryAccess(userId, req, {
         fetch,
         ipinfoToken: env.IPINFO_TOKEN,
+        spurToken: env.SPUR_TOKEN,
         ipHashSecret: env.NEXTAUTH_SECRET,
         allowLocalhost: env.NEXT_PUBLIC_CB_ENVIRONMENT === 'dev',
         forceLimited:
@@ -350,6 +353,9 @@ export async function postChatCompletions(params: {
       })
       freebuffAccessTier = getFreeModeAccessTier(countryAccess)
       const hardBlocked = shouldHardBlockFreeModeAccess(countryAccess)
+      const privacyDecision = getFreeModePrivacyDecision(countryAccess)
+      const privacyProviderDecision =
+        getFreeModePrivacyProviderDecision(countryAccess)
 
       if (!countryAccess.allowed || sampleFreebuffSuccess) {
         logger.info(
@@ -359,6 +365,11 @@ export async function postChatCompletions(params: {
             resolvedCountry: countryAccess.countryCode,
             countryBlockReason: countryAccess.blockReason,
             ipPrivacySignals: countryAccess.ipPrivacy?.signals,
+            spurIpPrivacySignals: countryAccess.spurIpPrivacy?.signals,
+            spurStatus: countryAccess.spurStatus,
+            privacyDecision,
+            privacyProviderDecision,
+            privacyHardBlocked: hardBlocked,
             clientIp: countryAccess.hasClientIp ? '[redacted]' : undefined,
           },
           'Free mode country detection',
@@ -380,6 +391,11 @@ export async function postChatCompletions(params: {
             countryCode: countryAccess.countryCode,
             countryBlockReason: countryAccess.blockReason,
             ipPrivacySignals: countryAccess.ipPrivacy?.signals,
+            spurIpPrivacySignals: countryAccess.spurIpPrivacy?.signals,
+            spurStatus: countryAccess.spurStatus,
+            privacyDecision,
+            privacyProviderDecision,
+            privacyHardBlocked: hardBlocked,
             clientIp: countryAccess.hasClientIp ? '[redacted]' : undefined,
             accessStatus: 'blocked',
           },
@@ -400,6 +416,10 @@ export async function postChatCompletions(params: {
       trackEvent = withDefaultProperties(trackEvent, {
         accessTier: freebuffAccessTier,
         accessStatus: freebuffAccessTier,
+        privacyDecision,
+        privacyProviderDecision,
+        privacyHardBlocked: hardBlocked,
+        spurStatus: countryAccess.spurStatus,
       })
 
       if (!countryAccess.allowed) {
@@ -411,6 +431,11 @@ export async function postChatCompletions(params: {
             countryCode: countryAccess.countryCode,
             countryBlockReason: countryAccess.blockReason,
             ipPrivacySignals: countryAccess.ipPrivacy?.signals,
+            spurIpPrivacySignals: countryAccess.spurIpPrivacy?.signals,
+            spurStatus: countryAccess.spurStatus,
+            privacyDecision,
+            privacyProviderDecision,
+            privacyHardBlocked: hardBlocked,
             clientIp: countryAccess.hasClientIp ? '[redacted]' : undefined,
           },
           logger,

--- a/web/src/app/api/v1/freebuff/session/__tests__/session.test.ts
+++ b/web/src/app/api/v1/freebuff/session/__tests__/session.test.ts
@@ -16,6 +16,10 @@ import type { InternalSessionRow } from '@/server/free-session/types'
 import type { NextRequest } from 'next/server'
 
 const DEFAULT_MODEL = 'minimax/minimax-m2.7'
+const NOT_CHECKED_SPUR_CONTEXT = {
+  spurIpPrivacy: null,
+  spurStatus: 'not_checked' as const,
+}
 
 function testCountryAccess(req: NextRequest): FreeModeCountryAccess {
   const cfCountry = req.headers.get('cf-ipcountry')?.toUpperCase() ?? null
@@ -32,6 +36,7 @@ function testCountryAccess(req: NextRequest): FreeModeCountryAccess {
       cfCountry,
       geoipCountry: null,
       ipPrivacy: cfCountry === 'T1' ? { signals: ['tor'] } : null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp,
       clientIpHash: hasClientIp ? 'test-ip-hash' : null,
     }
@@ -44,6 +49,7 @@ function testCountryAccess(req: NextRequest): FreeModeCountryAccess {
       cfCountry,
       geoipCountry: null,
       ipPrivacy: null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp,
       clientIpHash: hasClientIp ? 'test-ip-hash' : null,
     }
@@ -56,6 +62,7 @@ function testCountryAccess(req: NextRequest): FreeModeCountryAccess {
       cfCountry,
       geoipCountry: null,
       ipPrivacy: null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp,
       clientIpHash: 'test-ip-hash',
     }
@@ -67,6 +74,7 @@ function testCountryAccess(req: NextRequest): FreeModeCountryAccess {
     cfCountry,
     geoipCountry: null,
     ipPrivacy: { signals: [] },
+    ...NOT_CHECKED_SPUR_CONTEXT,
     hasClientIp,
     clientIpHash: 'test-ip-hash',
   }
@@ -314,6 +322,8 @@ describe('POST /api/v1/freebuff/session', () => {
           cfCountry: 'US',
           geoipCountry: null,
           ipPrivacy: { signals: ['vpn', 'hosting'] },
+          spurIpPrivacy: { signals: ['vpn'] },
+          spurStatus: 'suspicious',
           hasClientIp: true,
           clientIpHash: 'test-ip-hash',
         }),
@@ -343,18 +353,20 @@ describe('POST /api/v1/freebuff/session', () => {
     expect(sessionDeps.rows.size).toBe(0)
   })
 
-  test('keeps hosting-only privacy signals in limited mode', async () => {
+  test('allows full access when hosting-only privacy signals are cleared by Spur', async () => {
     const sessionDeps = makeSessionDeps()
     const resp = await postFreebuffSession(
       makeReq('ok', { cfCountry: 'US' }),
       makeDeps(sessionDeps, 'u1', {
         getCountryAccess: async () => ({
-          allowed: false,
+          allowed: true,
           countryCode: 'US',
-          blockReason: 'anonymous_network',
+          blockReason: null,
           cfCountry: 'US',
           geoipCountry: null,
           ipPrivacy: { signals: ['hosting'] },
+          spurIpPrivacy: { signals: [] },
+          spurStatus: 'clean',
           hasClientIp: true,
           clientIpHash: 'test-ip-hash',
         }),
@@ -363,8 +375,8 @@ describe('POST /api/v1/freebuff/session', () => {
     expect(resp.status).toBe(200)
     const body = await resp.json()
     expect(body.status).toBe('queued')
-    expect(body.accessTier).toBe('limited')
-    expect(body.ipPrivacySignals).toEqual(['hosting'])
+    expect(body.accessTier).toBe('full')
+    expect(body.ipPrivacySignals).toBeUndefined()
   })
 
   test('returns model_unavailable for legacy GLM 5.1 outside deployment hours', async () => {
@@ -424,18 +436,20 @@ describe('GET /api/v1/freebuff/session', () => {
     expect(body.ipPrivacySignals).toBeNull()
   })
 
-  test('returns limited-mode privacy reason on GET for hosting-only signal', async () => {
+  test('returns full access on GET when hosting-only privacy signal is cleared by Spur', async () => {
     const sessionDeps = makeSessionDeps()
     const resp = await getFreebuffSession(
       makeReq('ok', { cfCountry: 'US' }),
       makeDeps(sessionDeps, 'u1', {
         getCountryAccess: async () => ({
-          allowed: false,
+          allowed: true,
           countryCode: 'US',
-          blockReason: 'anonymous_network',
+          blockReason: null,
           cfCountry: 'US',
           geoipCountry: null,
           ipPrivacy: { signals: ['hosting'] },
+          spurIpPrivacy: { signals: [] },
+          spurStatus: 'clean',
           hasClientIp: true,
           clientIpHash: 'test-ip-hash',
         }),
@@ -444,10 +458,10 @@ describe('GET /api/v1/freebuff/session', () => {
     expect(resp.status).toBe(200)
     const body = await resp.json()
     expect(body.status).toBe('none')
-    expect(body.accessTier).toBe('limited')
-    expect(body.countryCode).toBe('US')
-    expect(body.countryBlockReason).toBe('anonymous_network')
-    expect(body.ipPrivacySignals).toEqual(['hosting'])
+    expect(body.accessTier).toBe('full')
+    expect(body.countryCode).toBeUndefined()
+    expect(body.countryBlockReason).toBeUndefined()
+    expect(body.ipPrivacySignals).toBeUndefined()
   })
 
   test('returns country_blocked on GET for VPN/proxy privacy signals', async () => {
@@ -473,6 +487,8 @@ describe('GET /api/v1/freebuff/session', () => {
           cfCountry: 'US',
           geoipCountry: null,
           ipPrivacy: { signals: ['res_proxy'] },
+          spurIpPrivacy: { signals: ['res_proxy'] },
+          spurStatus: 'suspicious',
           hasClientIp: true,
           clientIpHash: 'test-ip-hash',
         }),

--- a/web/src/app/api/v1/freebuff/session/_handlers.ts
+++ b/web/src/app/api/v1/freebuff/session/_handlers.ts
@@ -9,6 +9,8 @@ import {
 } from '@/server/free-session/public-api'
 import {
   getFreeModeAccessTier,
+  getFreeModePrivacyDecision,
+  getFreeModePrivacyProviderDecision,
   shouldHardBlockFreeModeAccess,
 } from '@/server/free-mode-country'
 import { getCachedFreeModeCountryAccess } from '@/server/free-mode-country-access-cache'
@@ -39,6 +41,7 @@ async function getCountryAccess(
       logger: deps.logger,
       options: {
         ipinfoToken: env.IPINFO_TOKEN,
+        spurToken: env.SPUR_TOKEN,
         ipHashSecret: env.NEXTAUTH_SECRET,
         allowLocalhost: env.NEXT_PUBLIC_CB_ENVIRONMENT === 'dev',
         forceLimited:
@@ -76,12 +79,46 @@ function hardBlockedResponse(countryAccess: FreeModeCountryAccess) {
   return NextResponse.json(
     {
       status: 'country_blocked',
-      message: formatFreebuffHardBlockedMessage(countryAccess.ipPrivacy?.signals),
+      message: formatFreebuffHardBlockedMessage(
+        countryAccess.ipPrivacy?.signals,
+      ),
       countryCode: countryAccess.countryCode ?? 'UNKNOWN',
       countryBlockReason: countryAccess.blockReason ?? undefined,
       ipPrivacySignals: countryAccess.ipPrivacy?.signals ?? undefined,
     },
     { status: 403 },
+  )
+}
+
+function logCountryAccess(
+  route: 'GET' | 'POST',
+  userId: string,
+  countryAccess: FreeModeCountryAccess,
+  deps: FreebuffSessionDeps,
+): void {
+  const privacyProviderDecision =
+    getFreeModePrivacyProviderDecision(countryAccess)
+  if (countryAccess.allowed && privacyProviderDecision !== 'ipinfo_only') return
+
+  const privacyHardBlocked = shouldHardBlockFreeModeAccess(countryAccess)
+  deps.logger.info(
+    {
+      route,
+      userId,
+      accessTier: getFreeModeAccessTier(countryAccess),
+      cfHeader: countryAccess.cfCountry,
+      geoipResult: countryAccess.geoipCountry,
+      resolvedCountry: countryAccess.countryCode,
+      countryBlockReason: countryAccess.blockReason,
+      ipPrivacySignals: countryAccess.ipPrivacy?.signals,
+      spurIpPrivacySignals: countryAccess.spurIpPrivacy?.signals,
+      spurStatus: countryAccess.spurStatus,
+      privacyDecision: getFreeModePrivacyDecision(countryAccess),
+      privacyProviderDecision,
+      privacyHardBlocked,
+      clientIp: countryAccess.hasClientIp ? '[redacted]' : undefined,
+    },
+    '[freebuff/session] country detection',
   )
 }
 
@@ -190,6 +227,7 @@ export async function postFreebuffSession(
   if ('error' in auth) return auth.error
 
   const countryAccess = await getCountryAccess(auth.userId, req, deps)
+  logCountryAccess('POST', auth.userId, countryAccess, deps)
   if (shouldHardBlockFreeModeAccess(countryAccess)) {
     await endSessionForHardBlock(auth, deps)
     return hardBlockedResponse(countryAccess)
@@ -241,6 +279,7 @@ export async function getFreebuffSession(
 
   try {
     const countryAccess = await getCountryAccess(auth.userId, req, deps)
+    logCountryAccess('GET', auth.userId, countryAccess, deps)
     if (shouldHardBlockFreeModeAccess(countryAccess)) {
       await endSessionForHardBlock(auth, deps)
       return hardBlockedResponse(countryAccess)

--- a/web/src/server/__tests__/free-mode-country-access-cache.test.ts
+++ b/web/src/server/__tests__/free-mode-country-access-cache.test.ts
@@ -6,8 +6,10 @@ import {
   FREE_MODE_COUNTRY_CACHE_ALLOWED_TTL_MS,
   FREE_MODE_COUNTRY_CACHE_ANONYMOUS_NETWORK_TTL_MS,
   FREE_MODE_COUNTRY_CACHE_COUNTRY_NOT_ALLOWED_TTL_MS,
+  FREE_MODE_COUNTRY_CACHE_SPUR_CLEARED_TTL_MS,
   FREE_MODE_COUNTRY_CACHE_TRANSIENT_BLOCK_TTL_MS,
   getCachedFreeModeCountryAccess,
+  shouldIgnoreCountryAccessCacheRow,
 } from '../free-mode-country-access-cache'
 import { hashClientIp } from '../free-mode-country'
 
@@ -34,6 +36,8 @@ function allowedAccess(): FreeModeCountryAccess {
     cfCountry: 'US',
     geoipCountry: null,
     ipPrivacy: { signals: [] },
+    spurIpPrivacy: null,
+    spurStatus: 'not_checked',
     hasClientIp: true,
     clientIpHash,
   }
@@ -59,6 +63,7 @@ describe('free mode country access cache', () => {
       options: {
         fetch,
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         ipHashSecret,
       },
       cacheStore,
@@ -97,6 +102,7 @@ describe('free mode country access cache', () => {
       options: {
         fetch,
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         ipHashSecret,
       },
       cacheStore,
@@ -107,6 +113,126 @@ describe('free mode country access cache', () => {
     expect(access.countryCode).toBe('US')
     expect(stored[0]).toEqual(access)
     expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not persist corroborated hard privacy blocks', async () => {
+    const cacheStore: FreeModeCountryAccessCacheStore = {
+      get: mock(async () => null),
+      set: mock(async () => {}),
+    }
+
+    const access = await getCachedFreeModeCountryAccess({
+      userId,
+      req: makeReq({
+        'cf-ipcountry': 'US',
+        'cf-connecting-ip': clientIp,
+      }),
+      options: {
+        ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
+        ipHashSecret,
+        lookupIpPrivacy: async () => ({ signals: ['vpn'] }),
+        lookupSpurIpPrivacy: async () => ({ signals: ['vpn'] }),
+      },
+      cacheStore,
+      now,
+    })
+
+    expect(access.allowed).toBe(false)
+    expect(access.spurIpPrivacy?.signals).toEqual(['vpn'])
+    expect(access.spurStatus).toBe('suspicious')
+    expect(cacheStore.set).not.toHaveBeenCalled()
+  })
+
+  test('stores transient limited decisions when Spur fails after hard IPinfo signals', async () => {
+    const cacheStore: FreeModeCountryAccessCacheStore = {
+      get: mock(async () => null),
+      set: mock(async () => {}),
+    }
+
+    const access = await getCachedFreeModeCountryAccess({
+      userId,
+      req: makeReq({
+        'cf-ipcountry': 'US',
+        'cf-connecting-ip': clientIp,
+      }),
+      options: {
+        ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
+        ipHashSecret,
+        lookupIpPrivacy: async () => ({ signals: ['vpn'] }),
+        lookupSpurIpPrivacy: async () => null,
+      },
+      cacheStore,
+      now,
+    })
+
+    expect(access.allowed).toBe(false)
+    expect(access.spurStatus).toBe('failed')
+    expect(cacheStore.set).toHaveBeenCalledWith({
+      userId,
+      access,
+      now,
+    })
+    expect(expiresAtForCountryAccess(access, now).getTime() - now.getTime()).toBe(
+      FREE_MODE_COUNTRY_CACHE_TRANSIENT_BLOCK_TTL_MS,
+    )
+  })
+
+  test('stores allowed decisions when clean Spur context clears a hard IPinfo signal', async () => {
+    const cacheStore: FreeModeCountryAccessCacheStore = {
+      get: mock(async () => null),
+      set: mock(async () => {}),
+    }
+
+    const access = await getCachedFreeModeCountryAccess({
+      userId,
+      req: makeReq({
+        'cf-ipcountry': 'US',
+        'cf-connecting-ip': clientIp,
+      }),
+      options: {
+        ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
+        ipHashSecret,
+        lookupIpPrivacy: async () => ({ signals: ['vpn'] }),
+        lookupSpurIpPrivacy: async () => ({ signals: [] }),
+      },
+      cacheStore,
+      now,
+    })
+
+    expect(access.allowed).toBe(true)
+    expect(access.spurStatus).toBe('clean')
+    expect(cacheStore.set).toHaveBeenCalledWith({
+      userId,
+      access,
+      now,
+    })
+  })
+
+  test('ignores legacy anonymous network cache rows with hard IPinfo signals and no Spur status', () => {
+    expect(
+      shouldIgnoreCountryAccessCacheRow({
+        country_block_reason: 'anonymous_network',
+        ip_privacy_signals: ['vpn'],
+        spur_status: null,
+      }),
+    ).toBe(true)
+    expect(
+      shouldIgnoreCountryAccessCacheRow({
+        country_block_reason: 'anonymous_network',
+        ip_privacy_signals: ['vpn'],
+        spur_status: 'failed',
+      }),
+    ).toBe(false)
+    expect(
+      shouldIgnoreCountryAccessCacheRow({
+        country_block_reason: 'anonymous_network',
+        ip_privacy_signals: ['hosting'],
+        spur_status: null,
+      }),
+    ).toBe(false)
   })
 
   test('refreshes when the cache store reports a stale entry', async () => {
@@ -131,6 +257,7 @@ describe('free mode country access cache', () => {
       options: {
         fetch,
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         ipHashSecret,
       },
       cacheStore,
@@ -154,6 +281,29 @@ describe('free mode country access cache', () => {
         now,
       ).getTime() - now.getTime(),
     ).toBe(FREE_MODE_COUNTRY_CACHE_ANONYMOUS_NETWORK_TTL_MS)
+    expect(
+      expiresAtForCountryAccess(
+        {
+          ...base,
+          ipPrivacy: { signals: ['vpn'] },
+          spurIpPrivacy: { signals: [] },
+          spurStatus: 'clean',
+        },
+        now,
+      ).getTime() - now.getTime(),
+    ).toBe(FREE_MODE_COUNTRY_CACHE_SPUR_CLEARED_TTL_MS)
+    expect(
+      expiresAtForCountryAccess(
+        {
+          ...base,
+          allowed: false,
+          blockReason: 'anonymous_network',
+          ipPrivacy: { signals: ['hosting'] },
+          spurStatus: 'failed',
+        },
+        now,
+      ).getTime() - now.getTime(),
+    ).toBe(FREE_MODE_COUNTRY_CACHE_TRANSIENT_BLOCK_TTL_MS)
     expect(
       expiresAtForCountryAccess(
         { ...base, allowed: false, blockReason: 'country_not_allowed' },

--- a/web/src/server/__tests__/free-mode-country.test.ts
+++ b/web/src/server/__tests__/free-mode-country.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, test } from 'bun:test'
 import { NextRequest } from 'next/server'
 
 import {
+  getFreeModePrivacyProviderDecision,
+  getFreeModePrivacyDecision,
   getFreeModeCountryAccess,
   shouldHardBlockFreeModeAccess,
   lookupIpinfoPrivacy,
+  lookupSpurIpPrivacy,
+  privacySignalsFromSpur,
 } from '../free-mode-country'
 
 function makeReq(headers: Record<string, string> = {}): NextRequest {
@@ -15,6 +19,7 @@ function makeReq(headers: Record<string, string> = {}): NextRequest {
 
 const noAnonymousNetwork = {
   ipinfoToken: 'test-token',
+  spurToken: 'test-spur-token',
   lookupIpPrivacy: async () => ({ signals: [] }),
 }
 
@@ -129,6 +134,7 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async (ip) => {
           checkedIp = ip
           return { signals: [] }
@@ -139,7 +145,7 @@ describe('free mode country access', () => {
     expect(checkedIp).toBe('203.0.113.10')
   })
 
-  test('blocks allowlisted countries when the client IP is an anonymous network', async () => {
+  test('allows allowlisted countries when Spur does not corroborate IPinfo VPN detection', async () => {
     const access = await getFreeModeCountryAccess(
       makeReq({
         'cf-ipcountry': 'US',
@@ -147,18 +153,28 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async () => ({
           signals: ['vpn'],
         }),
+        lookupSpurIpPrivacy: async () => ({
+          signals: [],
+        }),
       },
     )
-    expect(access.allowed).toBe(false)
+    expect(access.allowed).toBe(true)
     expect(access.countryCode).toBe('US')
-    expect(access.blockReason).toBe('anonymous_network')
+    expect(access.blockReason).toBe(null)
     expect(access.ipPrivacy?.signals).toEqual(['vpn'])
+    expect(access.spurIpPrivacy?.signals).toEqual([])
+    expect(access.spurStatus).toBe('clean')
+    expect(getFreeModePrivacyDecision(access)).toBe(
+      'ipinfo_suspicious_spur_clean',
+    )
+    expect(getFreeModePrivacyProviderDecision(access)).toBe('ipinfo_only')
   })
 
-  test('blocks allowlisted countries when IPinfo reports a residential proxy', async () => {
+  test('allows allowlisted countries when Spur does not corroborate IPinfo residential proxy detection', async () => {
     const access = await getFreeModeCountryAccess(
       makeReq({
         'cf-ipcountry': 'US',
@@ -166,17 +182,23 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async () => ({
           signals: ['res_proxy'],
         }),
+        lookupSpurIpPrivacy: async () => ({
+          signals: [],
+        }),
       },
     )
-    expect(access.allowed).toBe(false)
-    expect(access.blockReason).toBe('anonymous_network')
+    expect(access.allowed).toBe(true)
+    expect(access.blockReason).toBe(null)
     expect(access.ipPrivacy?.signals).toEqual(['res_proxy'])
+    expect(access.spurIpPrivacy?.signals).toEqual([])
+    expect(access.spurStatus).toBe('clean')
   })
 
-  test('limits allowlisted countries when IPinfo reports hosting or service', async () => {
+  test('allows allowlisted countries when Spur does not corroborate IPinfo hosting or service detection', async () => {
     const access = await getFreeModeCountryAccess(
       makeReq({
         'cf-ipcountry': 'US',
@@ -184,14 +206,19 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async () => ({
           signals: ['hosting', 'service'],
         }),
+        lookupSpurIpPrivacy: async () => ({
+          signals: [],
+        }),
       },
     )
-    expect(access.allowed).toBe(false)
-    expect(access.blockReason).toBe('anonymous_network')
+    expect(access.allowed).toBe(true)
+    expect(access.blockReason).toBe(null)
     expect(access.ipPrivacy?.signals).toEqual(['hosting', 'service'])
+    expect(access.spurStatus).toBe('clean')
     expect(shouldHardBlockFreeModeAccess(access)).toBe(false)
   })
 
@@ -203,13 +230,22 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async () => ({
           signals: ['vpn', 'hosting'],
+        }),
+        lookupSpurIpPrivacy: async () => ({
+          signals: ['vpn'],
         }),
       },
     )
     expect(vpnAccess.allowed).toBe(false)
+    expect(vpnAccess.spurStatus).toBe('suspicious')
     expect(shouldHardBlockFreeModeAccess(vpnAccess)).toBe(true)
+    expect(getFreeModePrivacyDecision(vpnAccess)).toBe('corroborated_block')
+    expect(getFreeModePrivacyProviderDecision(vpnAccess)).toBe(
+      'corroborated_hard',
+    )
 
     const anonymousOnlyAccess = await getFreeModeCountryAccess(
       makeReq({
@@ -218,13 +254,45 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async () => ({
           signals: ['anonymous', 'relay'],
+        }),
+        lookupSpurIpPrivacy: async () => ({
+          signals: ['vpn'],
         }),
       },
     )
     expect(anonymousOnlyAccess.allowed).toBe(false)
     expect(shouldHardBlockFreeModeAccess(anonymousOnlyAccess)).toBe(false)
+  })
+
+  test('keeps IPinfo VPN/proxy detections in limited mode when Spur lookup fails', async () => {
+    const access = await getFreeModeCountryAccess(
+      makeReq({
+        'cf-ipcountry': 'US',
+        'x-forwarded-for': '203.0.113.10',
+      }),
+      {
+        ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
+        lookupIpPrivacy: async () => ({
+          signals: ['vpn'],
+        }),
+        lookupSpurIpPrivacy: async () => {
+          throw new Error('provider unavailable')
+        },
+      },
+    )
+
+    expect(access.allowed).toBe(false)
+    expect(access.blockReason).toBe('anonymous_network')
+    expect(access.ipPrivacy?.signals).toEqual(['vpn'])
+    expect(access.spurIpPrivacy).toBe(null)
+    expect(access.spurStatus).toBe('failed')
+    expect(getFreeModePrivacyDecision(access)).toBe('spur_failed_limited')
+    expect(getFreeModePrivacyProviderDecision(access)).toBe('spur_failed')
+    expect(shouldHardBlockFreeModeAccess(access)).toBe(false)
   })
 
   test('allows allowlisted countries when privacy lookup finds no anonymous signals', async () => {
@@ -235,6 +303,7 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async () => ({
           signals: [],
         }),
@@ -252,6 +321,7 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         lookupIpPrivacy: async () => {
           throw new Error('provider unavailable')
         },
@@ -299,6 +369,7 @@ describe('free mode country access', () => {
       }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         ipHashSecret: 'secret',
         lookupIpPrivacy: async () => ({ signals: [] }),
       },
@@ -325,9 +396,90 @@ describe('free mode country access', () => {
     })
   })
 
+  test('parses Spur Context API anonymizer signals', async () => {
+    let requestedUrl = ''
+    let tokenHeader = ''
+    const fetch = async (url: string | URL | Request, init?: RequestInit) => {
+      requestedUrl = String(url)
+      tokenHeader =
+        init?.headers &&
+        typeof init.headers === 'object' &&
+        !Array.isArray(init.headers)
+          ? String((init.headers as Record<string, string>).Token)
+          : ''
+      return Response.json({
+        risks: ['CALLBACK_PROXY', 'GEO_MISMATCH'],
+        client: {
+          proxies: ['OXYLABS_PROXY'],
+        },
+        tunnels: [
+          {
+            type: 'VPN',
+            operator: 'PROTON_VPN',
+          },
+          {
+            type: 'TOR',
+          },
+        ],
+      })
+    }
+
+    const privacy = await lookupSpurIpPrivacy({
+      ip: '198.51.100.45',
+      token: 'spur-token',
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    })
+
+    expect(requestedUrl).toBe('https://api.spur.us/v2/context/198.51.100.45')
+    expect(tokenHeader).toBe('spur-token')
+    expect(privacy).toEqual({
+      signals: ['vpn', 'tor', 'proxy'],
+    })
+  })
+
+  test('parses Tor from Spur tunnel operator context', () => {
+    expect(
+      privacySignalsFromSpur({
+        tunnels: [
+          {
+            operator: 'TOR_PROXY',
+            type: 'PROXY',
+          },
+        ],
+      }),
+    ).toEqual(['tor', 'proxy'])
+  })
+
+  test('parses VPN protocol services from Spur context', () => {
+    expect(
+      privacySignalsFromSpur({
+        services: ['OPENVPN', 'WIREGUARD', 'HTTPS'],
+      }),
+    ).toEqual(['vpn'])
+  })
+
+  test('parses explicit Tor/proxy client behaviors from Spur context', () => {
+    expect(
+      privacySignalsFromSpur({
+        client: {
+          behaviors: ['FILE_SHARING', 'TOR_PROXY_USER'],
+        },
+      }),
+    ).toEqual(['tor'])
+  })
+
+  test('does not treat generic Spur proxy risk strings as corroboration', () => {
+    expect(
+      privacySignalsFromSpur({
+        risks: ['CALLBACK_PROXY'],
+      }),
+    ).toEqual([])
+  })
+
   test('allowLocalhost bypasses gating when no CF country and no client IP', async () => {
     const access = await getFreeModeCountryAccess(makeReq(), {
       ipinfoToken: 'test-token',
+      spurToken: 'test-spur-token',
       allowLocalhost: true,
     })
     expect(access.allowed).toBe(true)
@@ -341,6 +493,7 @@ describe('free mode country access', () => {
       makeReq({ 'x-forwarded-for': '127.0.0.1' }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         allowLocalhost: true,
       },
     )
@@ -354,6 +507,7 @@ describe('free mode country access', () => {
       makeReq({ 'cf-ipcountry': 'JP' }),
       {
         ipinfoToken: 'test-token',
+        spurToken: 'test-spur-token',
         allowLocalhost: true,
       },
     )
@@ -364,6 +518,7 @@ describe('free mode country access', () => {
   test('allowLocalhost off (default) keeps the strict missing-IP block', async () => {
     const access = await getFreeModeCountryAccess(makeReq(), {
       ipinfoToken: 'test-token',
+      spurToken: 'test-spur-token',
     })
     expect(access.allowed).toBe(false)
     expect(access.blockReason).toBe('missing_client_ip')

--- a/web/src/server/free-mode-country-access-cache.ts
+++ b/web/src/server/free-mode-country-access-cache.ts
@@ -6,8 +6,12 @@ import { and, eq, gt, isNull } from 'drizzle-orm'
 import {
   extractClientIp,
   getFreeModeCountryAccess,
+  getFreeModePrivacyDecision,
+  getFreeModePrivacyProviderDecision,
+  hasHardBlockedPrivacySignal,
   hashClientIp,
   IPINFO_PRIVACY_CACHE_TTL_MS,
+  shouldHardBlockFreeModeAccess,
 } from './free-mode-country'
 
 import type {
@@ -18,6 +22,7 @@ import type { Logger } from '@codebuff/common/types/contracts/logger'
 
 export const FREE_MODE_COUNTRY_CACHE_ALLOWED_TTL_MS =
   IPINFO_PRIVACY_CACHE_TTL_MS
+export const FREE_MODE_COUNTRY_CACHE_SPUR_CLEARED_TTL_MS = 10 * 60 * 1000
 export const FREE_MODE_COUNTRY_CACHE_ANONYMOUS_NETWORK_TTL_MS = 15 * 60 * 1000
 export const FREE_MODE_COUNTRY_CACHE_COUNTRY_NOT_ALLOWED_TTL_MS =
   6 * 60 * 60 * 1000
@@ -37,13 +42,45 @@ export type FreeModeCountryAccessCacheStore = {
   }): Promise<void>
 }
 
+export function shouldCacheCountryAccess(
+  access: FreeModeCountryAccess,
+): boolean {
+  return Boolean(access.clientIpHash) && !shouldHardBlockFreeModeAccess(access)
+}
+
+export function shouldIgnoreCountryAccessCacheRow(
+  row: Pick<
+    typeof schema.freeModeCountryAccessCache.$inferSelect,
+    'country_block_reason' | 'ip_privacy_signals' | 'spur_status'
+  >,
+): boolean {
+  return (
+    row.country_block_reason === 'anonymous_network' &&
+    row.spur_status === null &&
+    hasHardBlockedPrivacySignal(
+      row.ip_privacy_signals ? { signals: row.ip_privacy_signals } : null,
+    )
+  )
+}
+
 export function expiresAtForCountryAccess(
   access: FreeModeCountryAccess,
   now: Date,
 ): Date {
   let ttlMs = FREE_MODE_COUNTRY_CACHE_TRANSIENT_BLOCK_TTL_MS
-  if (access.allowed) {
+  if (
+    access.allowed &&
+    access.spurStatus === 'clean' &&
+    (access.ipPrivacy?.signals.length ?? 0) > 0
+  ) {
+    ttlMs = FREE_MODE_COUNTRY_CACHE_SPUR_CLEARED_TTL_MS
+  } else if (access.allowed) {
     ttlMs = FREE_MODE_COUNTRY_CACHE_ALLOWED_TTL_MS
+  } else if (
+    access.blockReason === 'anonymous_network' &&
+    access.spurStatus === 'failed'
+  ) {
+    ttlMs = FREE_MODE_COUNTRY_CACHE_TRANSIENT_BLOCK_TTL_MS
   } else if (access.blockReason === 'anonymous_network') {
     ttlMs = FREE_MODE_COUNTRY_CACHE_ANONYMOUS_NETWORK_TTL_MS
   } else if (access.blockReason === 'country_not_allowed') {
@@ -64,6 +101,10 @@ function countryAccessFromCacheRow(
     ipPrivacy: row.ip_privacy_signals
       ? { signals: row.ip_privacy_signals }
       : null,
+    spurIpPrivacy: row.spur_ip_privacy_signals
+      ? { signals: row.spur_ip_privacy_signals }
+      : null,
+    spurStatus: row.spur_status ?? 'not_checked',
     hasClientIp: true,
     clientIpHash: row.client_ip_hash,
   }
@@ -83,24 +124,34 @@ export const dbFreeModeCountryAccessCacheStore: FreeModeCountryAccessCacheStore 
         ),
       })
       if (!row) return null
+      if (shouldIgnoreCountryAccessCacheRow(row)) return null
       return countryAccessFromCacheRow(row)
     },
 
     async set({ userId, access, now }) {
-      if (!access.clientIpHash) return
+      if (!shouldCacheCountryAccess(access)) return
+
+      const clientIpHash = access.clientIpHash
+      if (!clientIpHash) return
 
       const expiresAt = expiresAtForCountryAccess(access, now)
+      const privacyDecision = getFreeModePrivacyDecision(access)
+      const privacyProviderDecision = getFreeModePrivacyProviderDecision(access)
       await db
         .insert(schema.freeModeCountryAccessCache)
         .values({
           user_id: userId,
-          client_ip_hash: access.clientIpHash,
+          client_ip_hash: clientIpHash,
           allowed: access.allowed,
           country_code: access.countryCode,
           cf_country: access.cfCountry,
           geoip_country: access.geoipCountry,
           country_block_reason: access.blockReason,
           ip_privacy_signals: access.ipPrivacy?.signals ?? null,
+          spur_ip_privacy_signals: access.spurIpPrivacy?.signals ?? null,
+          spur_status: access.spurStatus,
+          privacy_decision: privacyDecision,
+          privacy_provider_decision: privacyProviderDecision,
           checked_at: now,
           expires_at: expiresAt,
           created_at: now,
@@ -118,6 +169,10 @@ export const dbFreeModeCountryAccessCacheStore: FreeModeCountryAccessCacheStore 
             geoip_country: access.geoipCountry,
             country_block_reason: access.blockReason,
             ip_privacy_signals: access.ipPrivacy?.signals ?? null,
+            spur_ip_privacy_signals: access.spurIpPrivacy?.signals ?? null,
+            spur_status: access.spurStatus,
+            privacy_decision: privacyDecision,
+            privacy_provider_decision: privacyProviderDecision,
             checked_at: now,
             expires_at: expiresAt,
             updated_at: now,
@@ -170,7 +225,7 @@ export async function getCachedFreeModeCountryAccess(params: {
   }
 
   const access = await getFreeModeCountryAccess(req, options)
-  if (access.clientIpHash) {
+  if (shouldCacheCountryAccess(access)) {
     try {
       await cacheStore.set({ userId, access, now })
     } catch (error) {

--- a/web/src/server/free-mode-country.ts
+++ b/web/src/server/free-mode-country.ts
@@ -11,6 +11,9 @@ import type { FreebuffAccessTier } from '@codebuff/common/constants/freebuff-mod
 import type {
   FreebuffCountryBlockReason,
   FreebuffIpPrivacySignal,
+  FreebuffPrivacyDecision,
+  FreebuffPrivacyProviderDecision,
+  FreebuffSpurStatus,
 } from '@codebuff/common/types/freebuff-session'
 
 export const FREE_MODE_ALLOWED_COUNTRIES = new Set([
@@ -61,11 +64,17 @@ export type FreeModeCountryAccess = {
   cfCountry: string | null
   geoipCountry: string | null
   ipPrivacy: FreeModeIpPrivacy | null
+  spurIpPrivacy: FreeModeIpPrivacy | null
+  spurStatus: FreebuffSpurStatus
   hasClientIp: boolean
   clientIpHash: string | null
 }
 
 export type LookupIpPrivacyFn = (
+  ip: string,
+) => Promise<FreeModeIpPrivacy | null>
+
+export type LookupSpurIpPrivacyFn = (
   ip: string,
 ) => Promise<FreeModeIpPrivacy | null>
 
@@ -77,8 +86,10 @@ export function getFreeModeAccessTier(
 
 export type FreeModeCountryAccessOptions = {
   lookupIpPrivacy?: LookupIpPrivacyFn
+  lookupSpurIpPrivacy?: LookupSpurIpPrivacyFn
   fetch?: typeof globalThis.fetch
   ipinfoToken: string
+  spurToken: string
   ipHashSecret?: string
   allowLocalhost?: boolean
   /** Dev-only escape hatch: when true (and `allowLocalhost` is also true),
@@ -108,6 +119,10 @@ const ipinfoPrivacyCache = new Map<
   string,
   { expiresAt: number; privacy: FreeModeIpPrivacy | null }
 >()
+const spurPrivacyCache = new Map<
+  string,
+  { expiresAt: number; privacy: FreeModeIpPrivacy | null }
+>()
 
 const FREE_MODE_LIMITED_PRIVACY_SIGNALS = new Set<FreeModeIpPrivacySignal>([
   ...FREEBUFF_HARD_BLOCKED_PRIVACY_SIGNALS,
@@ -120,22 +135,99 @@ const FREE_MODE_LIMITED_PRIVACY_SIGNALS = new Set<FreeModeIpPrivacySignal>([
 export function hasHardBlockedPrivacySignal(
   ipPrivacy: FreeModeIpPrivacy | null | undefined,
 ): boolean {
-  return (
-    ipPrivacy?.signals.some(isFreebuffHardBlockedPrivacySignal) ?? false
-  )
+  return ipPrivacy?.signals.some(isFreebuffHardBlockedPrivacySignal) ?? false
 }
 
 export function shouldHardBlockFreeModeAccess(
   countryAccess: Pick<
     FreeModeCountryAccess,
-    'blockReason' | 'cfCountry' | 'ipPrivacy'
+    'blockReason' | 'cfCountry' | 'ipPrivacy' | 'spurIpPrivacy'
   >,
 ): boolean {
   return (
     countryAccess.cfCountry === CLOUDFLARE_TOR_COUNTRY ||
     (countryAccess.blockReason === 'anonymous_network' &&
-      hasHardBlockedPrivacySignal(countryAccess.ipPrivacy))
+      hasHardBlockedPrivacySignal(countryAccess.ipPrivacy) &&
+      hasHardBlockedPrivacySignal(countryAccess.spurIpPrivacy))
   )
+}
+
+export function getFreeModePrivacyDecision(
+  countryAccess: Pick<
+    FreeModeCountryAccess,
+    | 'allowed'
+    | 'blockReason'
+    | 'cfCountry'
+    | 'ipPrivacy'
+    | 'spurIpPrivacy'
+    | 'spurStatus'
+  >,
+): FreebuffPrivacyDecision {
+  if (countryAccess.allowed) {
+    return countryAccess.spurStatus === 'clean' &&
+      countryAccess.ipPrivacy?.signals.length
+      ? 'ipinfo_suspicious_spur_clean'
+      : 'allowed_clean'
+  }
+  if (countryAccess.cfCountry === CLOUDFLARE_TOR_COUNTRY) {
+    return 'cloudflare_tor_block'
+  }
+  if (countryAccess.blockReason === 'ip_privacy_lookup_failed') {
+    return 'ipinfo_failed_limited'
+  }
+  if (countryAccess.blockReason === 'anonymous_network') {
+    if (
+      hasHardBlockedPrivacySignal(countryAccess.ipPrivacy) &&
+      hasHardBlockedPrivacySignal(countryAccess.spurIpPrivacy)
+    ) {
+      return 'corroborated_block'
+    }
+    if (countryAccess.spurStatus === 'failed') {
+      return 'spur_failed_limited'
+    }
+  }
+  return 'limited_other'
+}
+
+export function getFreeModePrivacyProviderDecision(
+  countryAccess: Pick<
+    FreeModeCountryAccess,
+    | 'blockReason'
+    | 'cfCountry'
+    | 'ipPrivacy'
+    | 'spurIpPrivacy'
+    | 'spurStatus'
+  >,
+): FreebuffPrivacyProviderDecision {
+  if (countryAccess.cfCountry === CLOUDFLARE_TOR_COUNTRY) {
+    return 'cloudflare_tor'
+  }
+  if (countryAccess.blockReason === 'ip_privacy_lookup_failed') {
+    return 'ipinfo_failed'
+  }
+  if (!countryAccess.ipPrivacy) {
+    return 'not_checked'
+  }
+  if (countryAccess.ipPrivacy.signals.length === 0) {
+    return 'ipinfo_clean'
+  }
+  if (countryAccess.spurStatus === 'failed') {
+    return 'spur_failed'
+  }
+  if (countryAccess.spurStatus === 'clean') {
+    return 'ipinfo_only'
+  }
+  if (
+    countryAccess.spurStatus === 'suspicious' &&
+    hasHardBlockedPrivacySignal(countryAccess.ipPrivacy) &&
+    hasHardBlockedPrivacySignal(countryAccess.spurIpPrivacy)
+  ) {
+    return 'corroborated_hard'
+  }
+  if (countryAccess.spurStatus === 'suspicious') {
+    return 'corroborated_soft'
+  }
+  return 'not_checked'
 }
 
 export function extractClientIp(req: NextRequest): string | undefined {
@@ -176,6 +268,22 @@ function setIpinfoPrivacyCache(
   })
 }
 
+function setSpurPrivacyCache(
+  ip: string,
+  privacy: FreeModeIpPrivacy | null,
+): void {
+  while (spurPrivacyCache.size >= IPINFO_PRIVACY_CACHE_MAX_ENTRIES) {
+    const oldestIp = spurPrivacyCache.keys().next().value
+    if (!oldestIp) break
+    spurPrivacyCache.delete(oldestIp)
+  }
+
+  spurPrivacyCache.set(ip, {
+    expiresAt: Date.now() + IPINFO_PRIVACY_CACHE_TTL_MS,
+    privacy,
+  })
+}
+
 function privacySignalsFromIpinfo(
   data: Record<string, unknown>,
 ): FreeModeIpPrivacySignal[] {
@@ -201,6 +309,79 @@ function privacySignalsFromIpinfo(
   if (data.is_anonymous === true) {
     signals.push('anonymous')
   }
+  return signals
+}
+
+function pushUniqueSignal(
+  signals: FreeModeIpPrivacySignal[],
+  signal: FreeModeIpPrivacySignal,
+): void {
+  if (!signals.includes(signal)) signals.push(signal)
+}
+
+function signalFromSpurValue(value: unknown): FreeModeIpPrivacySignal | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.toUpperCase()
+  if (normalized.includes('RESIDENTIAL') || normalized.includes('RES_PROXY')) {
+    return 'res_proxy'
+  }
+  if (normalized.includes('TOR')) return 'tor'
+  if (normalized.includes('VPN')) return 'vpn'
+  if (normalized.includes('PROXY')) return 'proxy'
+  return null
+}
+
+function signalFromSpurService(value: unknown): FreeModeIpPrivacySignal | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.toUpperCase()
+  if (
+    normalized === 'OPENVPN' ||
+    normalized === 'WIREGUARD' ||
+    normalized === 'IPSEC' ||
+    normalized.includes('VPN')
+  ) {
+    return 'vpn'
+  }
+  return null
+}
+
+export function privacySignalsFromSpur(
+  data: Record<string, unknown>,
+): FreeModeIpPrivacySignal[] {
+  const signals: FreeModeIpPrivacySignal[] = []
+
+  const services = Array.isArray(data.services) ? data.services : []
+  for (const service of services) {
+    const signal = signalFromSpurService(service)
+    if (signal) pushUniqueSignal(signals, signal)
+  }
+
+  const tunnels = Array.isArray(data.tunnels) ? data.tunnels : []
+  for (const tunnel of tunnels) {
+    if (!tunnel || typeof tunnel !== 'object') continue
+    const tunnelRecord = tunnel as Record<string, unknown>
+    const operatorSignal = signalFromSpurValue(tunnelRecord.operator)
+    if (operatorSignal) pushUniqueSignal(signals, operatorSignal)
+    const signal = signalFromSpurValue(tunnelRecord.type)
+    if (signal) pushUniqueSignal(signals, signal)
+  }
+
+  const client =
+    data.client && typeof data.client === 'object'
+      ? (data.client as Record<string, unknown>)
+      : {}
+  const behaviors = Array.isArray(client.behaviors) ? client.behaviors : []
+  for (const behavior of behaviors) {
+    const signal = signalFromSpurValue(behavior)
+    if (signal) pushUniqueSignal(signals, signal)
+  }
+
+  const proxies = Array.isArray(client.proxies) ? client.proxies : []
+  for (const proxy of proxies) {
+    const signal = signalFromSpurValue(proxy) ?? 'proxy'
+    pushUniqueSignal(signals, signal)
+  }
+
   return signals
 }
 
@@ -230,6 +411,66 @@ export async function lookupIpinfoPrivacy(params: {
   return privacy
 }
 
+export async function lookupSpurIpPrivacy(params: {
+  ip: string
+  token: string
+  fetch: typeof globalThis.fetch
+}): Promise<FreeModeIpPrivacy | null> {
+  const cached = spurPrivacyCache.get(params.ip)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.privacy
+  }
+
+  const response = await params.fetch(
+    `https://api.spur.us/v2/context/${encodeURIComponent(params.ip)}`,
+    {
+      headers: {
+        Token: params.token,
+      },
+    },
+  )
+  if (!response.ok) {
+    return null
+  }
+
+  const data = (await response.json()) as Record<string, unknown>
+  const privacy = {
+    signals: privacySignalsFromSpur(data),
+  }
+  setSpurPrivacyCache(params.ip, privacy)
+  return privacy
+}
+
+async function lookupSpurPrivacyStatus(
+  clientIp: string,
+  options: FreeModeCountryAccessOptions,
+): Promise<{
+  privacy: FreeModeIpPrivacy | null
+  status: FreebuffSpurStatus
+}> {
+  try {
+    const privacy = options.lookupSpurIpPrivacy
+      ? await options.lookupSpurIpPrivacy(clientIp)
+      : await lookupSpurIpPrivacy({
+          ip: clientIp,
+          token: options.spurToken,
+          fetch: options.fetch ?? globalThis.fetch,
+        })
+    if (!privacy) return { privacy: null, status: 'failed' }
+    return {
+      privacy,
+      status: hasHardBlockedPrivacySignal(privacy) ? 'suspicious' : 'clean',
+    }
+  } catch {
+    return { privacy: null, status: 'failed' }
+  }
+}
+
+const NOT_CHECKED_SPUR_CONTEXT = {
+  spurIpPrivacy: null,
+  spurStatus: 'not_checked' as const,
+}
+
 export async function getFreeModeCountryAccess(
   req: NextRequest,
   options: FreeModeCountryAccessOptions,
@@ -256,6 +497,7 @@ export async function getFreeModeCountryAccess(
         cfCountry: null,
         geoipCountry: null,
         ipPrivacy: { signals: [] },
+        ...NOT_CHECKED_SPUR_CONTEXT,
         hasClientIp: Boolean(clientIp),
         // Null hash skips the country-access cache so toggling the env var
         // takes effect immediately without evicting prior allowed=true rows.
@@ -269,6 +511,7 @@ export async function getFreeModeCountryAccess(
       cfCountry: null,
       geoipCountry: null,
       ipPrivacy: { signals: [] },
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp: Boolean(clientIp),
       clientIpHash,
     }
@@ -283,6 +526,7 @@ export async function getFreeModeCountryAccess(
       geoipCountry: null,
       ipPrivacy:
         cfCountry === CLOUDFLARE_TOR_COUNTRY ? { signals: ['tor'] } : null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp: Boolean(clientIp),
       clientIpHash,
     }
@@ -295,6 +539,7 @@ export async function getFreeModeCountryAccess(
       countryCode: cfCountry,
       cfCountry,
       geoipCountry: null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp: Boolean(clientIp),
       clientIpHash,
     }
@@ -306,6 +551,7 @@ export async function getFreeModeCountryAccess(
       cfCountry: null,
       geoipCountry: null,
       ipPrivacy: null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp: false,
       clientIpHash,
     }
@@ -319,6 +565,7 @@ export async function getFreeModeCountryAccess(
         cfCountry: null,
         geoipCountry: null,
         ipPrivacy: null,
+        ...NOT_CHECKED_SPUR_CONTEXT,
         hasClientIp: true,
         clientIpHash,
       }
@@ -328,6 +575,7 @@ export async function getFreeModeCountryAccess(
       countryCode: geoipCountry,
       cfCountry: null,
       geoipCountry,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp: true,
       clientIpHash,
     }
@@ -339,6 +587,7 @@ export async function getFreeModeCountryAccess(
       allowed: false,
       blockReason: 'country_not_allowed',
       ipPrivacy: null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       clientIpHash,
     }
   }
@@ -351,6 +600,7 @@ export async function getFreeModeCountryAccess(
       cfCountry,
       geoipCountry: null,
       ipPrivacy: null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       hasClientIp: false,
       clientIpHash,
     }
@@ -375,6 +625,7 @@ export async function getFreeModeCountryAccess(
       allowed: false,
       blockReason: 'ip_privacy_lookup_failed',
       ipPrivacy: null,
+      ...NOT_CHECKED_SPUR_CONTEXT,
       clientIpHash,
     }
   }
@@ -384,11 +635,28 @@ export async function getFreeModeCountryAccess(
       FREE_MODE_LIMITED_PRIVACY_SIGNALS.has(signal),
     )
   ) {
+    const { privacy: spurIpPrivacy, status: spurStatus } =
+      await lookupSpurPrivacyStatus(clientIp, options)
+
+    if (spurIpPrivacy && spurStatus === 'clean') {
+      return {
+        ...baseAccess,
+        allowed: true,
+        blockReason: null,
+        ipPrivacy,
+        spurIpPrivacy,
+        spurStatus,
+        clientIpHash,
+      }
+    }
+
     return {
       ...baseAccess,
       allowed: false,
       blockReason: 'anonymous_network',
       ipPrivacy,
+      spurIpPrivacy,
+      spurStatus,
       clientIpHash,
     }
   }
@@ -398,6 +666,8 @@ export async function getFreeModeCountryAccess(
     allowed: true,
     blockReason: null,
     ipPrivacy,
+    spurIpPrivacy: null,
+    spurStatus: 'not_checked',
     clientIpHash,
   }
 }


### PR DESCRIPTION
Adds Spur Context API as a required second opinion for Freebuff country/privacy gating so IPinfo-only proxy/VPN detections can be cleared while corroborated hard anonymizer traffic remains blocked.
Updates free-mode cache schema and migrations to persist Spur signals, normalized privacy decisions, provider disagreement categories, and safe TTL behavior including legacy-cache misses for pre-Spur hard IPinfo rows.
Adds chat and session logging/analytics for privacy tuning, keeps hard-blocked decisions uncached, and documents the new required `SPUR_TOKEN`.
Validation: focused Freebuff/Spur tests, web/internal/common typechecks, and `git diff --check`.