### PR TITLE
Keep base2 current date prompt fresh

### DIFF
--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -17,14 +17,6 @@ import {
   type SecretAgentDefinition,
 } from '../types/secret-agent-definition'
 
-function formatCurrentDate(date: Date): string {
-  return new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(date)
-}
-
 export function createBase2(
   mode: 'default' | 'free' | 'lite' | 'max' | 'fast',
   options?: {
@@ -138,7 +130,7 @@ export function createBase2(
 
     systemPrompt: `You are Buffy, a strategic assistant that orchestrates complex coding tasks through specialized sub-agents. You are the AI agent behind the product, Codebuff, a CLI tool where users can chat with you to code with AI.
 
-Current date: ${formatCurrentDate(new Date())}.
+Current date: ${PLACEHOLDER.CURRENT_DATE}.
 
 # Core Mandates
 

--- a/agents/types/secret-agent-definition.ts
+++ b/agents/types/secret-agent-definition.ts
@@ -23,6 +23,7 @@ export interface SecretAgentDefinition
 const placeholderNames = [
   'AGENT_NAME',
   'AGENTS_PROMPT',
+  'CURRENT_DATE',
   'FILE_TREE_PROMPT_SMALL',
   'FILE_TREE_PROMPT',
   'FILE_TREE_PROMPT_LARGE',

--- a/packages/agent-runtime/src/templates/__tests__/strings.test.ts
+++ b/packages/agent-runtime/src/templates/__tests__/strings.test.ts
@@ -1,7 +1,8 @@
 import { TEST_AGENT_RUNTIME_IMPL } from '@codebuff/common/testing/impl/agent-runtime'
 import { describe, test, expect, mock } from 'bun:test'
 
-import { getAgentPrompt } from '../strings'
+import { PLACEHOLDER } from '../types'
+import { formatCurrentDate, getAgentPrompt } from '../strings'
 
 import type { AgentTemplate } from '../types'
 import type { AgentState } from '@codebuff/common/types/session-state'
@@ -81,6 +82,38 @@ const createMockAgentTemplate = (
 })
 
 describe('getAgentPrompt', () => {
+  test('replaces CURRENT_DATE when formatting prompts', async () => {
+    const agentTemplate = createMockAgentTemplate({
+      id: 'date-agent',
+      systemPrompt: `Today is ${PLACEHOLDER.CURRENT_DATE}.`,
+    })
+    const agentTemplates: Record<string, AgentTemplate> = {
+      'date-agent': agentTemplate,
+    }
+
+    const result = await getAgentPrompt({
+      agentTemplate,
+      promptType: { type: 'systemPrompt' },
+      fileContext: createMockFileContext(),
+      agentState: createMockAgentState('date-agent'),
+      agentTemplates,
+      additionalToolDefinitions: async () => ({}),
+      logger: createMockLogger(),
+      apiKey: TEST_AGENT_RUNTIME_IMPL.apiKey,
+      databaseAgentCache: TEST_AGENT_RUNTIME_IMPL.databaseAgentCache,
+      fetchAgentFromDatabase: TEST_AGENT_RUNTIME_IMPL.fetchAgentFromDatabase,
+    })
+
+    expect(result).toBe(`Today is ${formatCurrentDate(new Date())}.`)
+    expect(result).not.toContain(PLACEHOLDER.CURRENT_DATE)
+  })
+
+  test('formats current date for prompts', () => {
+    expect(formatCurrentDate(new Date('2026-05-22T12:00:00Z'))).toBe(
+      'May 22, 2026',
+    )
+  })
+
   describe('spawnerPrompt inclusion in instructionsPrompt', () => {
     test('includes spawnerPrompt for each spawnable agent with spawnerPrompt defined', async () => {
       const filePickerTemplate = createMockAgentTemplate({

--- a/packages/agent-runtime/src/templates/__tests__/strings.test.ts
+++ b/packages/agent-runtime/src/templates/__tests__/strings.test.ts
@@ -109,7 +109,7 @@ describe('getAgentPrompt', () => {
   })
 
   test('formats current date for prompts', () => {
-    expect(formatCurrentDate(new Date('2026-05-22T12:00:00Z'))).toBe(
+    expect(formatCurrentDate(new Date(2026, 4, 22, 12))).toBe(
       'May 22, 2026',
     )
   })

--- a/packages/agent-runtime/src/templates/strings.ts
+++ b/packages/agent-runtime/src/templates/strings.ts
@@ -29,6 +29,14 @@ import type {
   ProjectFileContext,
 } from '@codebuff/common/util/file'
 
+export function formatCurrentDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date)
+}
+
 export async function formatPrompt(
   params: {
     prompt: string
@@ -85,6 +93,7 @@ export async function formatPrompt(
   const toInject: Record<PlaceholderValue, () => string | Promise<string>> = {
     [PLACEHOLDER.AGENT_NAME]: () =>
       agentTemplate ? agentTemplate.displayName || 'Unknown Agent' : 'Buffy',
+    [PLACEHOLDER.CURRENT_DATE]: () => formatCurrentDate(new Date()),
     [PLACEHOLDER.FILE_TREE_PROMPT_SMALL]: () =>
       getProjectFileTreePrompt({
         fileContext,

--- a/packages/agent-runtime/src/templates/types.ts
+++ b/packages/agent-runtime/src/templates/types.ts
@@ -13,6 +13,7 @@ export type { AgentTemplate, StepGenerator, StepHandler }
 
 const placeholderNames = [
   'AGENT_NAME',
+  'CURRENT_DATE',
   'FILE_TREE_PROMPT_SMALL',
   'FILE_TREE_PROMPT',
   'FILE_TREE_PROMPT_LARGE',


### PR DESCRIPTION
## Summary
- Add a `CURRENT_DATE` prompt placeholder.
- Resolve the date during prompt formatting so base2 receives a fresh current date at run time.
- Cover placeholder replacement and formatting with focused tests.

## Validation
- `bun test packages/agent-runtime/src/templates/__tests__/strings.test.ts`
- `bun run --cwd packages/agent-runtime typecheck`
- `bun run --cwd agents typecheck`
- `git diff --check`