### PR TITLE
chore: update gpt-5.5 family pricing

### DIFF
--- a/web/src/llm-api/openai.ts
+++ b/web/src/llm-api/openai.ts
@@ -31,6 +31,8 @@ const INPUT_TOKEN_COSTS: Record<string, number> = {
   'gpt-5.3-codex': 1.75,
   'gpt-5.4': 2.50,
   'gpt-5.4-codex': 1.25,
+  'gpt-5.5': 5,
+  'gpt-5.5-pro': 30,
   'gpt-4o-2024-11-20': 2.50,
   'gpt-4o-mini-2024-07-18': 0.15,
 }
@@ -44,6 +46,8 @@ const CACHED_INPUT_TOKEN_COSTS: Record<string, number> = {
   'gpt-5.3-codex': 0.175,
   'gpt-5.4': 0.25,
   'gpt-5.4-codex': 0.125,
+  'gpt-5.5': 0.5,
+  'gpt-5.5-pro': 0.0,
   'gpt-4o-2024-11-20': 1.25,
   'gpt-4o-mini-2024-07-18': 0.075,
 }
@@ -57,6 +61,8 @@ const OUTPUT_TOKEN_COSTS: Record<string, number> = {
   'gpt-5.3-codex': 14,
   'gpt-5.4': 15,
   'gpt-5.4-codex': 10,
+  'gpt-5.5': 30,
+  'gpt-5.5-pro': 180,
   'gpt-4o-2024-11-20': 10,
   'gpt-4o-mini-2024-07-18': 0.60,
 }


### PR DESCRIPTION
- follow up on https://github.com/CodebuffAI/codebuff/pull/755#issuecomment-4549683031
- gpt-5.5 only, again proof of work in the comments

btw, checked deepseek models pricing, and it's up to date (if using deepseek provider).

1. Beyond openai, deepseek (and gateways like openrouter, opencode-zen) what other providers would be worth refreshing? if any.
2. Any new providers youre considering adding or nah?