### PR TITLE
Fix safeReplace to replace all matches

### DIFF
--- a/common/src/util/__tests__/string.test.ts
+++ b/common/src/util/__tests__/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
-import { pluralize } from '../string'
+import { pluralize, safeReplace } from '../string'
 
 describe('pluralize', () => {
   it('should handle singular and plural cases correctly', () => {
@@ -237,3 +237,16 @@ describe('pluralize', () => {
   })
 })
 
+describe('safeReplace', () => {
+  it('should replace every occurrence of the search string', () => {
+    expect(safeReplace('alpha beta alpha', 'alpha', 'gamma')).toBe(
+      'gamma beta gamma',
+    )
+  })
+
+  it('should treat dollar signs in replacement text literally', () => {
+    expect(safeReplace('total: AMOUNT and AMOUNT', 'AMOUNT', '$& dollars')).toBe(
+      'total: $& dollars and $& dollars',
+    )
+  })
+})

--- a/common/src/util/string.ts
+++ b/common/src/util/string.ts
@@ -292,7 +292,7 @@ export const safeReplace = (
   replaceStr: string,
 ): string => {
   const escapedReplaceStr = replaceStr.replace(/\$/g, '$$$$')
-  return content.replace(searchStr, escapedReplaceStr)
+  return content.replaceAll(searchStr, escapedReplaceStr)
 }
 
 /**


### PR DESCRIPTION
## Summary
- update safeReplace to replace every matching occurrence instead of only the first
- add coverage for replacing multiple matches and keeping dollar signs literal in replacement text

## Validation
- env PATH=/Users/sandog/.real/.bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin /Users/sandog/.real/.bin/bun test common/src/util/__tests__/string.test.ts