### PR TITLE
Fix syntax error and bun test crash

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,5 +3,9 @@ linker = "hoisted"
 linkWorkspacePackages = true
 
 [test]
-exclude = ["**/*.integration.test.*", "freebuff/e2e/**"]
+pathIgnorePatterns = [
+    "**/*.integration.test.*", 
+    "freebuff/e2e/**", 
+    "agents/librarian/**"   # Comment this if you have CODEBUFF_API_KEY
+    ]
 preload = ["./sdk/test/setup-env.ts"]


### PR DESCRIPTION
bunfig.toml has syntax error. It should be pathIgnorePatterns.
official doc: https://bun.com/docs/test/configuration

I also added "agents/librarian/**"  to the pathIgnorePatterns for those who do not have CODEBUFF_API_KEY, otherwise 'bun test' would crash. Ignoring it would allow the test to finish.