### PR TITLE
docs(readme): fix broken evals link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Instead of using one model for everything, Codebuff coordinates specialized agen
   <img src="./assets/codebuff-vs-claude-code.png" alt="Codebuff vs Claude Code" width="400">
 </div>
 
-Codebuff beats Claude Code at 61% vs 53% on [our evals](evals/README.md) across 175+ coding tasks over multiple open-source repos that simulate real-world tasks.
+Codebuff beats Claude Code at 61% vs 53% on [our evals](evals/buffbench/README.md) across 175+ coding tasks over multiple open-source repos that simulate real-world tasks.
 
 ## Freebuff: the free coding agent
 


### PR DESCRIPTION
## Problem\n\nREADME.md links to `evals/README.md` on line 13, but that file does not exist. Clicking the "our evals" link from the rendered README results in a 404.\n\n## Triage / Root cause\n\nPR #255 ([chore] Update readmes) introduced the `[our evals](evals/README.md)` link, but the target file was never present in the public tree. The actual evaluation documentation lives at `evals/buffbench/README.md`.\n\n## Fix\n\nUpdate the link target from `evals/README.md` to `evals/buffbench/README.md`. This is the minimal, existing doc that describes the BuffBench evaluation framework referenced by the 61% vs 53% comparison.\n\n## Verification\n\n- `python3` markdown link scan of `README.md`, `CONTRIBUTING.md`, and `docs/**/*.md*` confirmed `evals/README.md` is the only missing relative link.\n- `ls -l evals/buffbench/README.md` confirms the new target exists and documents the evaluation framework.\n- `python3 ../scripts/preflight_ship.py --repo CodebuffAI/codebuff --local codebuff --branch main --file README.md --must-contain '[our evals](evals/README.md)' --search 'evals/README.md in:title,body'` passed, confirming the bug marker is still on upstream/main and no open duplicate PR exists.\n\n## Notes / Risks\n\nNo code changes. Only the README link is updated, so there is no risk to runtime behavior. The PR title and commit follow the repo's existing `docs(scope): ...` convention.