### PR TITLE
fix(cli): reload .agents MCP servers after project picker selection

### DIFF
--- a/cli/src/__tests__/integration/local-agents.test.ts
+++ b/cli/src/__tests__/integration/local-agents.test.ts
@@ -21,9 +21,11 @@ import {
   loadAgentDefinitions,
   loadLocalAgents,
   initializeAgentRegistry,
+  reloadLocalAgentRegistry,
   findAgentsDirectory,
   getLoadedAgentsData,
   getLoadedAgentsMessage,
+  getLoadedMCPServers,
   announceLoadedAgents,
   __resetLocalAgentRegistryForTests,
 } from '../../utils/local-agent-registry'
@@ -1183,5 +1185,43 @@ describe('Local Agent Integration', () => {
           e.message.toLowerCase().includes('output'),
       ),
     ).toBe(true)
+  })
+
+  test('reloads MCP servers from the selected project after a project change', async () => {
+    // Simulates the project picker flow: the CLI is started from an ancestor
+    // directory (no mcp.json in the launch cwd), then the user selects a
+    // project whose .agents/mcp.json defines MCP servers.
+    const projectDir = path.join(tempDir, 'selected-project')
+    const projectAgentsDir = path.join(projectDir, '.agents')
+    mkdirSync(projectAgentsDir, { recursive: true })
+    writeFileSync(
+      path.join(projectAgentsDir, 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          context7: {
+            type: 'http',
+            url: 'https://mcp.context7.com/mcp',
+          },
+        },
+      }),
+      'utf8',
+    )
+
+    // Launch: registry initialized from the ancestor directory, so the
+    // selected project's servers are not present yet
+    await initializeAgentRegistry()
+    expect(getLoadedMCPServers()).not.toHaveProperty('context7')
+
+    // Project change: chdir + setProjectRoot like handleProjectChange does,
+    // then the registry must reload so mcp.json is picked up
+    process.chdir(projectDir)
+    setProjectRoot(projectDir)
+    await reloadLocalAgentRegistry()
+
+    expect(getLoadedMCPServers()).toHaveProperty('context7')
+    expect(getLoadedMCPServers().context7).toMatchObject({
+      type: 'http',
+      url: 'https://mcp.context7.com/mcp',
+    })
   })
 })

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -34,7 +34,10 @@ import { getAuthToken, getAuthTokenDetails } from './utils/auth'
 import { resetCodebuffClient } from './utils/codebuff-client'
 import { setApiClientAuthToken } from './utils/codebuff-api'
 import { IS_FREEBUFF } from './utils/constants'
-import { initializeAgentRegistry } from './utils/local-agent-registry'
+import {
+  initializeAgentRegistry,
+  reloadLocalAgentRegistry,
+} from './utils/local-agent-registry'
 import { trimOversizedChatLogs } from './utils/chat-history'
 import { clearLogFile, logger } from './utils/logger'
 import { drainClientLogs } from './utils/log-shipper'
@@ -356,6 +359,11 @@ async function main(): Promise<void> {
         })
         // Update the project root in the module state
         setProjectRoot(newProjectPath)
+        // Reload local agents and MCP servers for the newly selected project.
+        // The registry is initialized once at startup from the launch cwd, so
+        // when the CLI was started from an ancestor directory the selected
+        // project's .agents/mcp.json was never loaded.
+        await reloadLocalAgentRegistry()
         // Reset client to ensure tools use the updated project root
         resetCodebuffClient()
         // Save to recent projects list

--- a/cli/src/utils/local-agent-registry.ts
+++ b/cli/src/utils/local-agent-registry.ts
@@ -90,6 +90,21 @@ export async function initializeAgentRegistry(): Promise<void> {
 }
 
 /**
+ * Reload the local agent registry for the current working directory.
+ *
+ * Called after the project changes at runtime (e.g. the project picker), where
+ * the CLI was started from an ancestor directory so .agents content was read
+ * from the old cwd at startup. Clears the derived caches before re-initializing
+ * so agent listings, the resolved .agents directory, and MCP servers from the
+ * newly selected project's mcp.json all reflect the new working directory.
+ */
+export async function reloadLocalAgentRegistry(): Promise<void> {
+  cachedAgentsByMode.clear()
+  cachedAgentsDir = null
+  await initializeAgentRegistry()
+}
+
+/**
  * Get default agent directories to scan.
  * Matches the SDK's getDefaultAgentDirs() to ensure consistency.
  */


### PR DESCRIPTION
## Summary

Fixes #957. MCP servers from a project's `.agents/mcp.json` were only loaded once at CLI startup from the launch cwd. When the CLI is started from an ancestor directory and the project is selected via the project picker, the registry was never re-initialized, so the selected project's MCP servers stayed invisible to the main agent.

## Root cause

`initializeAgentRegistry()` runs once at startup and calls `loadMCPConfigSync()`, which reads `{cwd}/.agents/mcp.json`. `handleProjectChange` in `cli/src/index.tsx` changes the working directory and resets the codebuff client, but never re-runs the agent registry, so `mcpServersCache` stays empty and `loadAgentDefinitions()` merges nothing into the base agents.

## Changes

- `cli/src/utils/local-agent-registry.ts`: new `reloadLocalAgentRegistry()` that clears the derived caches (agent listings and the resolved `.agents` directory) and re-runs `initializeAgentRegistry()`.
- `cli/src/index.tsx`: `handleProjectChange` now awaits `reloadLocalAgentRegistry()` right after `process.chdir` and `setProjectRoot`.

## Verification

- New regression test in `cli/src/__tests__/integration/local-agents.test.ts` reproduces the report exactly: registry initialized in a directory without `mcp.json`, then chdir + setProjectRoot into a project that has one, then reload. It fails on the original code (the export does not exist) and passes with the fix.
- Local Agent Integration suite: 37/37 pass.
- `tsc --noEmit` on `cli/`: no errors in the changed files.