### PR TITLE
fix(llm-providers): pass complete data URLs through image conversion

### DIFF
--- a/packages/llm-providers/src/openai-compatible/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/llm-providers/src/openai-compatible/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -74,6 +74,33 @@ describe('user messages', () => {
     ])
   })
 
+  it('should not double-wrap an already-complete data URL', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'data:image/png;base64,AAECAw==',
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AAECAw==' },
+          },
+        ],
+      },
+    ])
+  })
+
   it('should handle URL-based images', async () => {
     const result = convertToOpenAICompatibleChatMessages([
       {

--- a/packages/llm-providers/src/openai-compatible/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/llm-providers/src/openai-compatible/chat/convert-to-openai-compatible-chat-messages.ts
@@ -41,14 +41,21 @@ export function convertToOpenAICompatibleChatMessages(
                   const mediaType =
                     part.mediaType === 'image/*' ? 'image/jpeg' : part.mediaType
 
+                  const dataUrl =
+                    part.data instanceof URL
+                      ? part.data.toString()
+                      : typeof part.data === 'string' &&
+                          part.data.startsWith('data:')
+                        ? // Already a complete data URL (e.g. produced by a
+                          // screenshot tool): wrapping it again would nest a
+                          // second `data:<mime>;base64,` prefix inside the
+                          // payload, which providers reject as invalid base64.
+                          part.data
+                        : `data:${mediaType};base64,${convertToBase64(part.data)}`
+
                   return {
                     type: 'image_url',
-                    image_url: {
-                      url:
-                        part.data instanceof URL
-                          ? part.data.toString()
-                          : `data:${mediaType};base64,${convertToBase64(part.data)}`,
-                    },
+                    image_url: { url: dataUrl },
                     ...partMetadata,
                   }
                 } else {


### PR DESCRIPTION
## What

Screenshot tools can hand the OpenAI-compatible converter a **complete** `data:<mime>;base64,...` URL instead of raw base64. The converter in `packages/llm-providers` unconditionally wrapped every string value in a second `data:<mime>;base64,` prefix, producing payloads like:

```
data:image/png;base64,data:image/png;base64,iVBORw0KG...
```

The nested prefix injects `:` and `,` characters where providers expect base64, so requests fail with:

```
Invalid 'input[126].content[0].image_url'. Expected a base64-encoded data URL with an image MIME type, but got an invalid base64-encoded value.
```

Vision-capable models are affected because media is only attached to them — text-only models never receive an image part, so the bug hides.

## Fix

Detect a leading `data:` prefix in string data and pass the value through untouched. Raw base64 strings, `Uint8Array`, `ArrayBuffer`, `Buffer`, and `URL` inputs behave exactly as before (existing tests unchanged).

## Why here

The producing tool lives in the private client; the converter is the public chokepoint every OpenAI-compatible provider path goes through, so hardening it fixes the whole class of double-wrapped media regardless of which tool produced the data.

## Testing

- New regression test: an already-complete data URL is emitted unchanged (no double prefix).
- `bun test packages/llm-providers/` — 31 pass, 0 fail.
- `bun run typecheck` (package) — clean.
- Prettier — clean.

Fixes #977