### PR TITLE
fix: handle Windows startup access violations

### DIFF
--- a/cli/release-core/launcher.js
+++ b/cli/release-core/launcher.js
@@ -127,9 +127,10 @@ function createLauncher(productConfig) {
    * perfectly capable machine to the slower build.
    */
   function isStartupCpuFeatureCrash(code, signal, msAlive) {
+    const unsignedCode = getUnsignedExitCode(code)
     return (
       process.platform === 'win32' &&
-      getUnsignedExitCode(code) === 0xc0000409 &&
+      (unsignedCode === 0xc0000409 || unsignedCode === 0xc0000005) &&
       !signal &&
       typeof msAlive === 'number' &&
       msAlive < STARTUP_CRASH_WINDOW_MS

--- a/cli/src/__tests__/launcher-avx2-fallback.test.ts
+++ b/cli/src/__tests__/launcher-avx2-fallback.test.ts
@@ -340,9 +340,10 @@ describe('illegal-instruction detection', () => {
  * STATUS_STACK_BUFFER_OVERRUN instead — and those users crash-looped forever.
  */
 describe('windows startup-abort detection', () => {
-  test('recognizes an immediate 0xC0000409 as a CPU-feature suspect', () => {
+  test('recognizes immediate Windows startup CPU-feature crashes', () => {
     const t = makeLauncher()
     expect(t.isStartupCpuFeatureCrash(0xc0000409, null, 40)).toBe(true)
+    expect(t.isStartupCpuFeatureCrash(0xc0000005, null, 40)).toBe(true)
     // Node surfaces the NTSTATUS signed, same as the SIGILL spelling.
     expect(t.isStartupCpuFeatureCrash(-1073740791, null, 40)).toBe(true)
   })
@@ -358,7 +359,6 @@ describe('windows startup-abort detection', () => {
 
   test('other native crashes and signals are not this one', () => {
     const t = makeLauncher()
-    expect(t.isStartupCpuFeatureCrash(0xc0000005, null, 40)).toBe(false)
     expect(t.isStartupCpuFeatureCrash(0xc000001d, null, 40)).toBe(false)
     expect(t.isStartupCpuFeatureCrash(1, null, 40)).toBe(false)
     expect(t.isStartupCpuFeatureCrash(0xc0000409, 'SIGTERM', 40)).toBe(false)


### PR DESCRIPTION
## Summary

Fixes #1091.

On Windows, a `0xC0000005` (`STATUS_ACCESS_VIOLATION`) crash from the optimized binary during the startup window can indicate a CPU compatibility problem. The launcher already falls back to the baseline binary for `0xC0000409`, but did not handle `0xC0000005`.

This change:

- treats `0xC0000005` as a startup CPU-feature crash
- keeps the existing startup-time guard so normal runtime access violations are unaffected
- adds regression coverage for the new fallback case
