### PR TITLE
fix(cli): queue custom reviews while busy

### DIFF
--- a/cli/src/commands/__tests__/review-queue.test.ts
+++ b/cli/src/commands/__tests__/review-queue.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+import { buildReviewPrompt } from '../prompt-builders'
+import { routeUserPrompt } from '../router'
+import { useChatStore } from '../../state/chat-store'
+
+import type { RouterParams } from '../command-registry'
+
+const createMockParams = (
+  overrides: Partial<RouterParams> = {},
+): RouterParams => ({
+  agentMode: 'DEFAULT',
+  inputRef: { current: null },
+  inputValue: 'focus on the authentication flow',
+  isChainInProgressRef: { current: false },
+  isStreaming: false,
+  logoutMutation: {} as RouterParams['logoutMutation'],
+  streamMessageIdRef: { current: null },
+  addToQueue: mock(() => {}),
+  clearMessages: mock(() => {}),
+  saveToHistory: mock(() => {}),
+  scrollToLatest: mock(() => {}),
+  sendMessage: mock(async () => {}),
+  setCanProcessQueue: mock(() => {}),
+  setInputFocused: mock(() => {}),
+  setInputValue: mock(() => {}),
+  setIsAuthenticated: mock(() => {}),
+  setMessages: mock(() => {}),
+  setUser: mock(() => {}),
+  ...overrides,
+})
+
+describe('custom review routing', () => {
+  afterEach(() => {
+    useChatStore.getState().reset()
+  })
+
+  test('queues a custom review while a response is in progress', async () => {
+    const attachment = {
+      kind: 'text' as const,
+      id: 'requirements',
+      content: 'Review the login requirements.',
+      preview: 'Review the login requirements.',
+      charCount: 32,
+    }
+    const addToQueue = mock(() => {})
+    const sendMessage = mock(async () => {})
+    useChatStore.setState({
+      inputMode: 'review',
+      pendingAttachments: [attachment],
+    })
+
+    const params = createMockParams({
+      addToQueue,
+      isStreaming: true,
+      sendMessage,
+    })
+
+    await routeUserPrompt(params)
+
+    expect(addToQueue).toHaveBeenCalledWith(
+      buildReviewPrompt('custom', params.inputValue),
+      [attachment],
+    )
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(useChatStore.getState().pendingAttachments).toEqual([])
+  })
+
+  test('sends a custom review immediately when idle', async () => {
+    const addToQueue = mock(() => {})
+    const sendMessage = mock(async () => {})
+    useChatStore.setState({ inputMode: 'review' })
+
+    const params = createMockParams({ addToQueue, sendMessage })
+
+    await routeUserPrompt(params)
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      content: buildReviewPrompt('custom', params.inputValue),
+      agentMode: params.agentMode,
+    })
+    expect(addToQueue).not.toHaveBeenCalled()
+  })
+})

--- a/cli/src/commands/router.ts
+++ b/cli/src/commands/router.ts
@@ -352,7 +352,18 @@ export async function routeUserPrompt(
     setInputFocused(true)
     inputRef.current?.focus()
 
-    sendMessage({ content: buildReviewPrompt('custom', trimmed), agentMode })
+    const reviewPrompt = buildReviewPrompt('custom', trimmed)
+    if (
+      isStreaming ||
+      streamMessageIdRef.current ||
+      isChainInProgressRef.current
+    ) {
+      const pendingAttachmentsForQueue = capturePendingAttachments()
+      addToQueue(reviewPrompt, pendingAttachmentsForQueue)
+      return
+    }
+
+    sendMessage({ content: reviewPrompt, agentMode })
     setTimeout(() => {
       scrollToLatest()
     }, 0)


### PR DESCRIPTION
## Summary
- queue custom review prompts when a response or agent chain is already active
- preserve pending attachments when the review is queued
- keep the existing immediate-send behavior when the CLI is idle
- add regression coverage for both busy and idle review routing

Fixes #674

## Validation
- targeted review/router tests: 94 passed
- message queue tests: 6 passed
- new review routing tests: 2 passed
- common and SDK typechecks: passed
- CLI typecheck: existing checkout errors for missing `tar` and `react-dom/server` declarations; no errors from changed files
- `git diff --check`: passed