### PR TITLE
fix(cli): detect Wayland sessions for clipboard

### DIFF
--- a/cli/src/types/env.ts
+++ b/cli/src/types/env.ts
@@ -30,6 +30,7 @@ export type CliEnv = BaseEnv & {
   // Display server detection (Linux headless check)
   DISPLAY?: string
   WAYLAND_DISPLAY?: string
+  XDG_SESSION_TYPE?: string
 
   // Terminal-specific
   KITTY_WINDOW_ID?: string

--- a/cli/src/utils/__tests__/clipboard-linux.test.ts
+++ b/cli/src/utils/__tests__/clipboard-linux.test.ts
@@ -75,6 +75,7 @@ describe('copyTextToClipboard - Linux platform tools', () => {
     originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     originalEnv = {
       WAYLAND_DISPLAY: process.env.WAYLAND_DISPLAY,
+      XDG_SESSION_TYPE: process.env.XDG_SESSION_TYPE,
       SSH_CLIENT: process.env.SSH_CLIENT,
       SSH_TTY: process.env.SSH_TTY,
       SSH_CONNECTION: process.env.SSH_CONNECTION,
@@ -88,6 +89,7 @@ describe('copyTextToClipboard - Linux platform tools', () => {
     delete process.env.SSH_CLIENT
     delete process.env.SSH_TTY
     delete process.env.SSH_CONNECTION
+    delete process.env.XDG_SESSION_TYPE
     process.env.TERM = 'dumb'
     clearClipboardMessage()
     unregisterClipboardRenderer()
@@ -138,6 +140,19 @@ describe('copyTextToClipboard - Linux platform tools', () => {
     expect(attempts[0]?.args).toEqual(['--type', 'text/plain'])
     expect(attempts[0]?.process.input()).toBe('hello')
     expect(fallbackCalls).toBe(0)
+  })
+
+  test('uses wl-copy when Wayland is identified by the session type', async () => {
+    delete process.env.WAYLAND_DISPLAY
+    process.env.XDG_SESSION_TYPE = 'wayland'
+    mockBackends(() => 0)
+
+    await copyTextToClipboard('hello', { suppressGlobalMessage: true })
+
+    expect(attempts).toHaveLength(1)
+    expect(attempts[0]?.command).toBe('wl-copy')
+    expect(attempts[0]?.args).toEqual(['--type', 'text/plain'])
+    expect(attempts[0]?.process.input()).toBe('hello')
   })
 
   test('falls back from wl-copy through the X11 tools in order', async () => {

--- a/cli/src/utils/clipboard.ts
+++ b/cli/src/utils/clipboard.ts
@@ -322,7 +322,10 @@ async function tryCopyViaPlatformTool(
       ['xclip', ['-selection', 'clipboard']],
       ['xsel', ['--clipboard', '--input']],
     ]
-    return getCliEnv().WAYLAND_DISPLAY
+    const env = getCliEnv()
+    const isWayland =
+      Boolean(env.WAYLAND_DISPLAY) || env.XDG_SESSION_TYPE === 'wayland'
+    return isWayland
       ? [['wl-copy', ['--type', 'text/plain']], ...x11Commands]
       : x11Commands
   })()

--- a/cli/src/utils/env.ts
+++ b/cli/src/utils/env.ts
@@ -22,6 +22,7 @@ export const getCliEnv = (): CliEnv => ({
   // Display server detection (Linux headless check)
   DISPLAY: process.env.DISPLAY,
   WAYLAND_DISPLAY: process.env.WAYLAND_DISPLAY,
+  XDG_SESSION_TYPE: process.env.XDG_SESSION_TYPE,
 
   // Terminal detection (for tmux/screen passthrough)
   TERM: process.env.TERM,


### PR DESCRIPTION
## Summary

- treat `XDG_SESSION_TYPE=wayland` as a Wayland session when `WAYLAND_DISPLAY` is missing
- try the native `wl-copy` backend before X11 fallbacks in that environment
- add the session variable to the typed CLI environment and regression coverage

Fixes #1085

## Validation

- Linux clipboard tests: 12 passed
- clipboard tests: 34 passed, 7 skipped
- CLI typecheck: existing missing `tar` and `react-dom/server` declarations; no changed-file errors
- Prettier check passed
- `git diff --check` passed